### PR TITLE
Configure optional trailing semicolons with 'semi' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Configure the formatter by creating a `.prettierrc` file. Learn more at [Prettie
 {
     "bracketSpacing": true,
     "printWidth": 80,
+    "semi": true,
     "tabWidth": 2,
     "trailingComma": "es5",
     "useTabs": false

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -214,7 +214,9 @@ function printTokenTree(
                 // Trailing delimiter
                 if (
                     (!isSeparator || isDelim) &&
-                    options.trailingComma !== 'none'
+                    (groupType === 'Unenclosed' || groupType === 'Curly'
+                        ? options.semi
+                        : options.trailingComma !== 'none')
                 ) {
                     results.push(
                         ifBreak(printToken(getGroupDelimToken(groupType))),

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -98,7 +98,10 @@ describe('Motoko formatter', () => {
         expect(format('(a\n,b,c)')).toStrictEqual('(\n  a,\n  b,\n  c,\n);\n');
         expect(format('(a\n,b,c,)')).toStrictEqual('(\n  a,\n  b,\n  c,\n);\n');
         expect(format('(a\n,b,c,)', { trailingComma: 'none' })).toStrictEqual(
-            '(\n  a,\n  b,\n  c\n)\n',
+            '(\n  a,\n  b,\n  c\n);\n',
+        );
+        expect(format('(a\n,b,c,)', { semi: false })).toStrictEqual(
+            '(\n  a,\n  b,\n  c,\n)\n',
         );
     });
 
@@ -127,6 +130,7 @@ describe('Motoko formatter', () => {
     //         const formatted = prettier.format(code, {
     //             filepath: file,
     //             plugins: [motokoPlugin],
+    //             semi: false,///
     //         });
 
     //         preOutput += `// >>> ${basename(file)} <<<\n\n${code}\n\n`;


### PR DESCRIPTION
Makes it possible to configure optional semicolons separately from trailing commas using the `semi` and `trailingComma` properties, respectively. 