### PR TITLE
v0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,13 @@
                 "fast-glob": "^3.2.11",
                 "jest": "^28.1.3",
                 "npm-run-all": "^4.1.5",
-                "rimraf": "^3.0.2",
                 "ts-jest": "^28.0.8",
                 "ts-node": "^10.9.1",
                 "typescript": "^4.7.4",
                 "wasm-pack": "^0.10.3"
             },
             "peerDependencies": {
-                "prettier": "^2"
+                "prettier": "^2.7"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.0.6",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.0.6",
+            "version": "0.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "run-s build:wasm build:typescript",
         "test": "npm run build:wasm && jest",
         "test:quick": "jest",
-        "prepare": "npm run build"
+        "prepublishOnly": "npm run build"
     },
     "devDependencies": {
         "@types/jest": "^28.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.0.6",
+    "version": "0.1.0",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/index.js",
     "scripts": {

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -136,6 +136,9 @@ const spaceConfig: SpaceConfig = {
 
         // space between identifier and group
         [tokenEquals('func'), 'Group', 'nil'],
+        [tokenEquals('debug_show'), 'Paren', 'nil'],
+        [tokenEquals('to_candid'), 'Paren', 'nil'],
+        [tokenEquals('from_candid'), 'Paren', 'nil'],
         [keyword, 'Group', 'space'],
         // ['Ident', 'Curly', 'nil'],
         ['Ident', 'Paren', 'nil'],

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -136,9 +136,6 @@ const spaceConfig: SpaceConfig = {
 
         // space between identifier and group
         [tokenEquals('func'), 'Group', 'nil'],
-        [tokenEquals('debug_show'), 'Paren', 'nil'],
-        [tokenEquals('to_candid'), 'Paren', 'nil'],
-        [tokenEquals('from_candid'), 'Paren', 'nil'],
         [keyword, 'Group', 'space'],
         // ['Ident', 'Curly', 'nil'],
         ['Ident', 'Paren', 'nil'],


### PR DESCRIPTION
Fixes the pre-publish build script for releasing `prettier-plugin-motoko@0.1.0`.
