### PR TITLE
Add lookahead/lookbehind for token spacing rules

### DIFF
--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -208,7 +208,10 @@ function printTokenTree(
             }
             if (i < trees.length - 1) {
                 const b = trees[i + 1]!;
-                resultArray.push(printBetween(a, b, leftMap, rightMap));
+                // resultArray.push(printBetween(a, b, leftMap, rightMap));
+                resultArray.push(
+                    printBetween(trees, i, i + 1, leftMap, rightMap),
+                );
             } else if (results.length || resultGroup.length) {
                 endGroup();
                 // Trailing delimiter
@@ -277,18 +280,26 @@ function printToken(token: Token): Doc {
 }
 
 function printBetween(
-    a: TokenTree,
-    b: TokenTree,
+    trees: TokenTree[],
+    aIndex: number,
+    bIndex: number,
+    // a: TokenTree,
+    // b: TokenTree,
     leftMap: Map<TokenTree, TokenTree>,
     rightMap: Map<TokenTree, TokenTree>,
 ): Doc {
     const rule = spaceConfig.rules.find(([aPattern, bPattern]) => {
         return (
-            doesTokenTreeMatchPattern(a, aPattern) &&
-            doesTokenTreeMatchPattern(b, bPattern)
+            // doesTokenTreeMatchPattern(a, aPattern) &&
+            // doesTokenTreeMatchPattern(b, bPattern)
+            doesTokenTreeMatchPattern(aPattern, trees, aIndex) &&
+            doesTokenTreeMatchPattern(bPattern, trees, bIndex)
         );
     });
-    return rule ? parseSpace(rule[2], a, b, leftMap, rightMap) : [];
+    // return rule ? parseSpace(rule[2], a, b, leftMap, rightMap) : [];
+    return rule
+        ? parseSpace(rule[2], trees[aIndex], trees[bIndex], leftMap, rightMap)
+        : [];
 }
 
 export function getTokenText(token: Token): string {

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -63,6 +63,11 @@ describe('Motoko formatter', () => {
         expect(format('"A"# #b')).toStrictEqual('"A" # #b\n');
     });
 
+    test('do ? / optional', () => {
+        expect(format('?{}')).toStrictEqual('?{}\n');
+        expect(format('do?{}')).toStrictEqual('do ? {}\n');
+    });
+
     test('anonymous functions', () => {
         expect(format('func ():() {}')).toStrictEqual('func() : () {}\n');
         expect(format('func <T> () {}')).toStrictEqual('func<T>() {}\n');


### PR DESCRIPTION
Fixes a corner case where a `do ? {}` block is formatted as `do ?{}`. 