### PR TITLE
Implement `prettier-ignore` comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "run-s build:wasm build:typescript",
         "test": "npm run build:wasm && jest",
         "test:quick": "jest",
-        "prepublishOnly": "npm run build"
+        "prepublishOnly": "run-s build test:quick"
     },
     "devDependencies": {
         "@types/jest": "^28.1.7",

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -1,10 +1,11 @@
-import { getTokenText as getTokenText, Space } from './print';
+import { Space } from './print';
 import {
     Token,
     TokenTree,
     GroupType,
 } from '../../parsers/motoko-tt-parse/parse';
 import wasm from '../../wasm';
+import { getToken, getTokenText } from './utils';
 
 type Pattern =
     | Token['token_type']
@@ -83,7 +84,8 @@ const keyword = (tt: TokenTree): boolean => {
 const token =
     (fn: (token: Token) => boolean) =>
     (tt: TokenTree): boolean => {
-        return tt.token_tree_type === 'Token' && fn(tt.data[0]);
+        const token = getToken(tt);
+        return !!token && fn(token);
     };
 
 const tokenEquals = (data: string) =>
@@ -112,7 +114,6 @@ const spaceConfig: SpaceConfig = {
 
         // delimiters
         ['_', 'Delim', 'nil'],
-        // [tokenEquals(';'), '_', 'hardline'],
         ['Delim', '_', 'line'],
         // ['Delim', 'Line', 'nil'],
 

--- a/src/printers/motoko-tt-ast/utils.ts
+++ b/src/printers/motoko-tt-ast/utils.ts
@@ -1,5 +1,44 @@
+import { TokenTree, Token } from './../../parsers/motoko-tt-parse/parse';
 import { Doc } from 'prettier';
 
+/// Get the unmodified source text from a TokenTree
+export function getTokenTreeText(tree: TokenTree): string {
+    if (tree.token_tree_type === 'Group') {
+        const [trees, groupType, pair] = tree.data;
+        const results = trees.map((tt: TokenTree) => getTokenTreeText(tt));
+        return (
+            pair
+                ? [
+                      getTokenText(pair[0][0]),
+                      ...results,
+                      getTokenText(pair[1][0]),
+                  ]
+                : results
+        ).join('');
+    }
+    if (tree.token_tree_type === 'Token') {
+        return getTokenText(tree.data[0]);
+    }
+    throw new Error(`Unexpected token tree: ${JSON.stringify(tree)}`);
+}
+
+/// Get the unmodified source text from a Token
+export function getTokenText(token: Token): string {
+    if (Array.isArray(token.data)) {
+        return token.data[0];
+    } else {
+        return token.data;
+    }
+}
+
+/// Unwrap a single Token from a TokenTree
+export function getToken(tree: TokenTree | undefined): Token | undefined {
+    if (tree && tree.token_tree_type === 'Token') {
+        return tree.data[0];
+    }
+}
+
+/// Remove all line breaks from a Doc
 export function withoutLineBreaks(doc: Doc): Doc {
     if (Array.isArray(doc)) {
         return doc.map((d) => withoutLineBreaks(d));

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -163,6 +163,9 @@ describe('Motoko formatter', () => {
         expect(format('//prettier-ignore\n1*1;\n2*2')).toStrictEqual(
             '//prettier-ignore\n1*1;\n2 * 2;\n',
         );
+        expect(format('//prettier-ignore\n1*1;\n\n2*2')).toStrictEqual(
+            '//prettier-ignore\n1*1;\n\n2 * 2;\n',
+        );
         expect(format('// prettier-ignore\n{\nabc}')).toStrictEqual(
             '// prettier-ignore\n{\nabc}\n',
         );

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -73,20 +73,20 @@ describe('Motoko formatter', () => {
         expect(format('func <T> () {}')).toStrictEqual('func<T>() {}\n');
     });
 
-    // test('if-else wrapping', () => {
-    //     expect(format('if true () else ()')).toStrictEqual(
-    //         'if true () else ()\n',
-    //     );
-    //     expect(format('if true {} else {}')).toStrictEqual(
-    //         'if true {} else {}\n',
-    //     );
-    //     expect(format('if true (a) else (b)')).toStrictEqual(
-    //         'if true (a) else (b)\n',
-    //     );
-    //     expect(format('if true {a} else {b}')).toStrictEqual(
-    //         'if true {\n  a;\n} else {\n  b;\n};\n',
-    //     );
-    // });
+    test('if-else wrapping', () => {
+        expect(format('if true () else ()')).toStrictEqual(
+            'if true () else ()\n',
+        );
+        expect(format('if true {} else {}')).toStrictEqual(
+            'if true {} else {}\n',
+        );
+        expect(format('if true (a) else (b)')).toStrictEqual(
+            'if true (a) else (b)\n',
+        );
+        expect(format('if true {\na} else if false {\nb} else {\nc}')).toStrictEqual(
+            'if true {\n  a;\n} else if false {\n  b;\n} else {\n  c;\n};\n',
+        );
+    });
 
     test('type bindings', () => {
         expect(format('func foo<A<:Any>(x:A) {}')).toStrictEqual(

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -83,7 +83,9 @@ describe('Motoko formatter', () => {
         expect(format('if true (a) else (b)')).toStrictEqual(
             'if true (a) else (b)\n',
         );
-        expect(format('if true {\na} else if false {\nb} else {\nc}')).toStrictEqual(
+        expect(
+            format('if true {\na} else if false {\nb} else {\nc}'),
+        ).toStrictEqual(
             'if true {\n  a;\n} else if false {\n  b;\n} else {\n  c;\n};\n',
         );
     });
@@ -156,6 +158,27 @@ describe('Motoko formatter', () => {
             '{abc}\n',
         );
     });
+
+    test('prettier-ignore', () => {
+        expect(format('//prettier-ignore\n1*1;\n2*2')).toStrictEqual(
+            '//prettier-ignore\n1*1;\n2 * 2;\n',
+        );
+        expect(format('// prettier-ignore\n{\nabc}')).toStrictEqual(
+            '// prettier-ignore\n{\nabc}\n',
+        );
+        expect(format('/*prettier-ignore*/{\nabc\n\n1}')).toStrictEqual(
+            '/*prettier-ignore*/{\nabc\n\n1}\n',
+        );
+    });
+
+    // test('prettier-ignore-start / prettier-ignore-end', () => {
+    //     expect(format('//prettier-ignore-start\n1*1;//prettier-ignore-end\n2*2')).toStrictEqual(
+    //         '//prettier-ignore-start\n1*1;//prettier-ignore-end\n2 * 2;\n',
+    //     );
+    //     expect(format('/* prettier-ignore-start */{1\nabc/*prettier-ignore-end*/};abc')).toStrictEqual(
+    //         '/* prettier-ignore-start */{1\nabc/*prettier-ignore-end*/\n};\nabc;\n',
+    //     );
+    // });
 
     // test('generate diff files from compiler tests', () => {
     //     for (const extension of ['mo', 'did']) {


### PR DESCRIPTION
Adds support for `// prettier-ignore` and `/* prettier-ignore */` comments.

Examples:

```motoko
// prettier-ignore
do {
abc
}
```

```motoko
// prettier-ignore
func ignored<A>(a:A){a};

func formatted<B>(b: B) { b };
```

Resolves #30.
