### PR TITLE
Improve formatting rules for parenthesized expressions

### DIFF
--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -245,6 +245,7 @@ function printTokenTree(
                     if (
                         (!isSeparator || isDelim) &&
                         groupType !== 'Angle' &&
+                        groupType !== 'Paren' && // ??
                         (groupType === 'Unenclosed' || groupType === 'Curly'
                             ? options.semi
                             : options.trailingComma !== 'none')
@@ -263,26 +264,40 @@ function printTokenTree(
                 ? []
                 : groupType === 'Curly' && options.bracketSpacing
                 ? line
-                : groupType === 'Angle'
+                : groupType === 'Angle' || /* ??? */ groupType === 'Paren'
                 ? []
                 : softline;
 
-        const resultDoc = group(
-            pair
-                ? [
-                      printToken(pair[0][0]),
-                      //   pairSpace,
-                      //   results,
-                      indent([pairSpace, results]),
-                      pairSpace,
-                      printToken(pair[1][0]),
-                  ]
-                : results,
-            {
-                shouldBreak,
-            },
-        );
-        return groupType === 'Angle' ? withoutLineBreaks(resultDoc) : resultDoc;
+        // const resultDoc = group(
+        //     pair
+        //         ? [
+        //               printToken(pair[0][0]),
+        //               //   pairSpace,
+        //               //   results,
+        //               indent([pairSpace, results]),
+        //               pairSpace,
+        //               printToken(pair[1][0]),
+        //           ]
+        //         : results,
+        //     { shouldBreak },
+        // );
+        const resultDoc = pair
+            ? [
+                  printToken(pair[0][0]),
+                  //   pairSpace,
+                  //   results,
+                  indent([pairSpace, results]),
+                  pairSpace,
+                  printToken(pair[1][0]),
+              ]
+            : results;
+
+        // return groupType === 'Angle' ? withoutLineBreaks(resultDoc) : resultDoc;
+        return groupType === 'Angle'
+            ? withoutLineBreaks(resultDoc)
+            : groupType === 'Paren'
+            ? fill(resultDoc)
+            : group(resultDoc, { shouldBreak });
     } else if (tree.token_tree_type === 'Token') {
         const [token] = tree.data;
 

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -100,6 +100,11 @@ describe('Motoko formatter', () => {
     });
 
     test('type binding line breaks', () => {
+        const basic = `<${Array(5)
+            .fill(['x'.repeat(20)])
+            .join(', ')}>;\n`;
+        expect(format(basic)).toStrictEqual(basic);
+
         const parens = `<(${Array(5)
             .fill(['x'.repeat(20)])
             .join(', ')})>;\n`;
@@ -111,6 +116,14 @@ describe('Motoko formatter', () => {
         expect(format(parens)).toStrictEqual(parens);
     });
 
+    test('tuple line breaks', () => {
+        expect(format(`(${Array(5)
+            .fill(['x'.repeat(20)])
+            .join(', ')});\n`)).toStrictEqual(`(${Array(5)
+                .fill(['x'.repeat(20)])
+                .join(',\n  ')});\n`);
+    });
+
     // test('multi-line statement indentation', () => {
     //     const ident = 'x'.repeat(50)
     //     expect(format(`${ident}.${ident}.${ident}`)).toStrictEqual(`${ident}\n  .${ident}\n  .${ident}\n`);
@@ -119,7 +132,7 @@ describe('Motoko formatter', () => {
     test('dot after group', () => {
         expect(format('().0')).toStrictEqual('().0\n');
         // expect(format('(\n).0')).toStrictEqual('().0\n');
-        expect(format('(\n\n).0')).toStrictEqual('(\n\n).0;\n');
+        expect(format('{\n\n}.0')).toStrictEqual('{\n\n}.0;\n');
     });
 
     // test('cursor position', () => {
@@ -138,13 +151,13 @@ describe('Motoko formatter', () => {
     });
 
     test('add trailing delimiters', () => {
-        expect(format('(a\n,b,c)')).toStrictEqual('(\n  a,\n  b,\n  c,\n);\n');
-        expect(format('(a\n,b,c,)')).toStrictEqual('(\n  a,\n  b,\n  c,\n);\n');
-        expect(format('(a\n,b,c,)', { trailingComma: 'none' })).toStrictEqual(
-            '(\n  a,\n  b,\n  c\n);\n',
+        expect(format('[a\n,b,c]')).toStrictEqual('[\n  a,\n  b,\n  c,\n];\n');
+        expect(format('[a\n,b,c,]')).toStrictEqual('[\n  a,\n  b,\n  c,\n];\n');
+        expect(format('[a\n,b,c,]', { trailingComma: 'none' })).toStrictEqual(
+            '[\n  a,\n  b,\n  c\n];\n',
         );
-        expect(format('(a\n,b,c,)', { semi: false })).toStrictEqual(
-            '(\n  a,\n  b,\n  c,\n)\n',
+        expect(format('[a\n,b,c,]', { semi: false })).toStrictEqual(
+            '[\n  a,\n  b,\n  c,\n]\n',
         );
     });
 


### PR DESCRIPTION
**Current behavior:**

```motoko
test(
  "example test",
  func() {
    assert 1 == 1;
  },
);
```

**Expected behavior(?):**

```motoko
test("example test", func() {
  assert 1 == 1;
});
```