### PR TITLE
Add --ignore option to `mo-fmt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ npm install --save-dev prettier prettier-plugin-motoko
 Format your Motoko files using the [Prettier CLI](https://prettier.io/docs/en/cli.html):
 
 ```sh
-npm exec prettier -- --write **/*.mo
+npx prettier -- --write **/*.mo
 ```
 
 Check if your Motoko files are correctly formatted:
 
 ```sh
-npm exec prettier -- --check **/*.mo
+npx prettier -- --check **/*.mo
 ```
+
+Alternatively, check out [`mo-fmt`](https://github.com/dfinity/prettier-plugin-motoko/tree/main/package/mo-fmt) for a standalone Motoko formatter CLI.
 
 ## VS Code support
 

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mo-fmt",
-    "version": "0.0.5",
+    "version": "0.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.0.5",
+            "version": "0.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {

--- a/packages/mo-fmt/src/cli.js
+++ b/packages/mo-fmt/src/cli.js
@@ -9,9 +9,10 @@ const glob = require('fast-glob');
 
 // console.log(prettier.getSupportInfo().options);
 
-const { check } = program
+const { check, ignore } = program
     .argument('[paths...]', 'file paths to format', ['**/*.mo'])
     .option('-c, --check', 'check whether the files are formatted (instead of formatting)')
+    .option('-i, --ignore [paths]', 'file paths to ignore, comma-separated', '**/node_modules')
     .parse()
     .opts();
 
@@ -21,9 +22,10 @@ let fileCount = 0;
 let checkCount = 0;
 let formatCount = 0;
 
+const ignorePatterns = ignore.split(',');
 Promise.all(
     program.processedArgs[0].map(async (pattern) => {
-        for (const file of await glob(pattern)) {
+        for (const file of await glob(pattern, { onlyFiles: true, ignore: ignorePatterns })) {
             fileCount += 1;
             const source = readFileSync(file, 'utf-8');
             const shouldFormat = !prettier.check(source, {


### PR DESCRIPTION
Includes a CLI option for ignoring files and directories (defaults to `**/node_modules`).