### PR TITLE
Restrict `mo-fmt` to specified files

### DIFF
--- a/packages/mo-fmt/README.md
+++ b/packages/mo-fmt/README.md
@@ -22,15 +22,15 @@ For environments without Node.js, you can also download a portable executable fr
 # Format all Motoko files in-place
 mo-fmt **/*.mo
 
-# Format `Main.mo` in-place
-mo-fmt Main.mo
+# Format `File.mo` in-place
+mo-fmt File.mo
 
-# Format `Main.mo` and all `*.mo` files in the `lib/` directory
-mo-fmt Main.mo lib/*.mo
+# Format `File.mo` and all Motoko files in the `lib/` directory
+mo-fmt File.mo lib/*.mo
 
 # Check that all files are formatted
 mo-fmt -c **/*.mo
 
-# Quick reference
-mo-fmt --help
+# Show help information
+mo-fmt
 ```

--- a/packages/mo-fmt/README.md
+++ b/packages/mo-fmt/README.md
@@ -19,17 +19,17 @@ For environments without Node.js, you can also download a portable executable fr
 ## Usage
 
 ```bash
-# Format `**/*.mo` in-place
-mo-fmt
+# Format all Motoko files in-place
+mo-fmt **/*.mo
 
-# Format `File.mo` in-place
+# Format `Main.mo` in-place
 mo-fmt Main.mo
 
 # Format `Main.mo` and all `*.mo` files in the `lib/` directory
 mo-fmt Main.mo lib/*.mo
 
 # Check that all files are formatted
-mo-fmt -c
+mo-fmt -c **/*.mo
 
 # Quick reference
 mo-fmt --help

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mo-fmt",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
@@ -596,32 +596,6 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
-        "node_modules/@cspotcode/source-map-support": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "0.3.9"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
-            }
-        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1129,38 +1103,6 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "node_modules/@tsconfig/node10": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@tsconfig/node12": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@tsconfig/node14": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@tsconfig/node16": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@types/babel__core": {
             "version": "7.1.19",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -1305,17 +1247,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1395,14 +1326,6 @@
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
             }
-        },
-        "node_modules/arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "node_modules/argparse": {
             "version": "1.0.10",
@@ -1881,14 +1804,6 @@
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
         },
-        "node_modules/create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1999,17 +1914,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
         "node_modules/diff-sequences": {
             "version": "28.1.1",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
@@ -2032,9 +1936,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.235",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.235.tgz",
-            "integrity": "sha512-eNU2SmVZYTzYVA5aAWmhAJbdVil5/8H5nMq6kGD0Yxd4k2uKIuT8YmS46I0QXY7iOoPPcb6jjem9/2xyuH5+XQ==",
+            "version": "1.4.237",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.237.tgz",
+            "integrity": "sha512-vxVyGJcsgArNOVUJcXm+7iY3PJAfmSapEszQD1HbyPLl0qoCmNQ1o/EX3RI7Et5/88In9oLxX3SGF8J3orkUgA==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -3847,14 +3751,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "node_modules/makeerror": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -5011,9 +4907,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.78.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-            "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+            "version": "2.79.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
+            "integrity": "sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -5602,51 +5498,6 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true
         },
-        "node_modules/ts-node": {
-            "version": "10.9.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@cspotcode/source-map-support": "^0.8.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "v8-compile-cache-lib": "^3.0.1",
-                "yn": "3.1.1"
-            },
-            "bin": {
-                "ts-node": "dist/bin.js",
-                "ts-node-cwd": "dist/bin-cwd.js",
-                "ts-node-esm": "dist/bin-esm.js",
-                "ts-node-script": "dist/bin-script.js",
-                "ts-node-transpile-only": "dist/bin-transpile.js",
-                "ts-script": "dist/bin-script-deprecated.js"
-            },
-            "peerDependencies": {
-                "@swc/core": ">=1.2.50",
-                "@swc/wasm": ">=1.2.50",
-                "@types/node": "*",
-                "typescript": ">=2.7"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/wasm": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -5678,21 +5529,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/typescript": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
             }
         },
         "node_modules/unbox-primitive": {
@@ -5750,14 +5586,6 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
-        },
-        "node_modules/v8-compile-cache-lib": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.0.1",
@@ -5970,17 +5798,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/yocto-queue": {
@@ -6422,31 +6239,6 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
-        "@cspotcode/source-map-support": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "requires": {
-                "@jridgewell/trace-mapping": "0.3.9"
-            },
-            "dependencies": {
-                "@jridgewell/trace-mapping": {
-                    "version": "0.3.9",
-                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-                    "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "@jridgewell/resolve-uri": "^3.0.3",
-                        "@jridgewell/sourcemap-codec": "^1.4.10"
-                    }
-                }
-            }
-        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -6852,38 +6644,6 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "@tsconfig/node10": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@tsconfig/node12": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@tsconfig/node14": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@tsconfig/node16": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "@types/babel__core": {
             "version": "7.1.19",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -7022,14 +6782,6 @@
             "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
             "dev": true
         },
-        "acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -7088,14 +6840,6 @@
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
             }
-        },
-        "arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "argparse": {
             "version": "1.0.10",
@@ -7448,14 +7192,6 @@
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
         },
-        "create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7531,14 +7267,6 @@
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
         },
-        "diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "diff-sequences": {
             "version": "28.1.1",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
@@ -7555,9 +7283,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.235",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.235.tgz",
-            "integrity": "sha512-eNU2SmVZYTzYVA5aAWmhAJbdVil5/8H5nMq6kGD0Yxd4k2uKIuT8YmS46I0QXY7iOoPPcb6jjem9/2xyuH5+XQ==",
+            "version": "1.4.237",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.237.tgz",
+            "integrity": "sha512-vxVyGJcsgArNOVUJcXm+7iY3PJAfmSapEszQD1HbyPLl0qoCmNQ1o/EX3RI7Et5/88In9oLxX3SGF8J3orkUgA==",
             "dev": true
         },
         "emittery": {
@@ -8905,14 +8633,6 @@
                 "semver": "^6.0.0"
             }
         },
-        "make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "makeerror": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -9764,9 +9484,9 @@
             }
         },
         "rollup": {
-            "version": "2.78.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-            "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+            "version": "2.79.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
+            "integrity": "sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -10224,29 +9944,6 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true
         },
-        "ts-node": {
-            "version": "10.9.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "requires": {
-                "@cspotcode/source-map-support": "^0.8.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "v8-compile-cache-lib": "^3.0.1",
-                "yn": "3.1.1"
-            }
-        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10267,14 +9964,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true
-        },
-        "typescript": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "unbox-primitive": {
             "version": "1.0.2",
@@ -10309,14 +9998,6 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
-        },
-        "v8-compile-cache-lib": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "v8-to-istanbul": {
             "version": "9.0.1",
@@ -10492,14 +10173,6 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true
-        },
-        "yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "yocto-queue": {
             "version": "0.1.0",

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {

--- a/packages/mo-fmt/rollup.config.js
+++ b/packages/mo-fmt/rollup.config.js
@@ -1,6 +1,6 @@
-import nodeResolve from '@rollup/plugin-node-resolve';
+// import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import { terser } from 'rollup-plugin-terser';
+// import { terser } from 'rollup-plugin-terser';
 import json from '@rollup/plugin-json';
 
 export default {
@@ -11,9 +11,9 @@ export default {
         exports: 'auto',
     },
     plugins: [
-        nodeResolve(),
+        // nodeResolve(),
         commonjs(),
-        terser(),
+        // terser(),
         json(),
     ],
 };

--- a/packages/mo-fmt/src/cli.js
+++ b/packages/mo-fmt/src/cli.js
@@ -15,7 +15,15 @@ const { check, ignore } = program
     .parse()
     .opts();
 
-prettier.resolveConfig.sync(prettier.resolveConfigFile.sync());
+if (!program.args.length) {
+    console.log(program.helpInformation());
+    process.exit(0);
+}
+
+const configPath = prettier.resolveConfigFile.sync();
+if (configPath) {
+    prettier.resolveConfig.sync(configPath);
+}
 
 let fileCount = 0;
 let checkCount = 0;

--- a/packages/mo-fmt/src/cli.js
+++ b/packages/mo-fmt/src/cli.js
@@ -11,7 +11,7 @@ const glob = require('fast-glob');
 const { check, ignore } = program
     .argument('[paths...]', 'file paths to format (examples: File.mo, **/*.mo)')
     .option('-c, --check', 'check whether the files are formatted (instead of formatting)')
-    .option('-i, --ignore [paths]', 'file paths to ignore, comma-separated', '**/node_modules')
+    .option('-i, --ignore [paths]', 'file paths to ignore, comma-separated', '**/node_modules/**/*')
     .parse()
     .opts();
 
@@ -32,6 +32,10 @@ let formatCount = 0;
 const ignorePatterns = ignore.split(',');
 Promise.all(
     (program.processedArgs[0] || []).map(async (pattern) => {
+        // if (pattern.endsWith('*')) {
+        //     pattern = `${pattern}.{mo,did}`;
+        // }
+
         for (const file of await glob(pattern, { onlyFiles: true, ignore: ignorePatterns })) {
             // Enforce file extensions
             if (!file.endsWith('.mo') && !file.endsWith('.did')) {

--- a/packages/mo-fmt/src/cli.js
+++ b/packages/mo-fmt/src/cli.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { readFileSync, fstat, writeFileSync } = require('fs');
+const { readFileSync, writeFileSync } = require('fs');
 const motokoPlugin = require('prettier-plugin-motoko');
 const prettier = require('prettier');
 const { program } = require('commander');
@@ -9,7 +9,7 @@ const glob = require('fast-glob');
 // console.log(prettier.getSupportInfo().options);
 
 const { check, ignore } = program
-    .argument('[paths...]', 'file paths to format', ['**/*.mo'])
+    .argument('[paths...]', 'file paths to format (examples: File.mo, **/*.mo)')
     .option('-c, --check', 'check whether the files are formatted (instead of formatting)')
     .option('-i, --ignore [paths]', 'file paths to ignore, comma-separated', '**/node_modules')
     .parse()
@@ -23,8 +23,13 @@ let formatCount = 0;
 
 const ignorePatterns = ignore.split(',');
 Promise.all(
-    program.processedArgs[0].map(async (pattern) => {
+    (program.processedArgs[0] || []).map(async (pattern) => {
         for (const file of await glob(pattern, { onlyFiles: true, ignore: ignorePatterns })) {
+            // Enforce file extensions
+            if (!file.endsWith('.mo') && !file.endsWith('.did')) {
+                continue;
+            }
+
             fileCount += 1;
             const source = readFileSync(file, 'utf-8');
             const shouldFormat = !prettier.check(source, {


### PR DESCRIPTION
Reduces the chance of accidentally formatting more than expected when running `mo-fmt`.