### PR TITLE
Fix line wrapping corner case

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: git clone https://github.com/dfinity/motoko.rs ../motoko.rs
     - run: npm ci
     - run: npm i prettier
     - run: npm run build --if-present

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.1.9",
+            "version": "0.1.10",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.1.8",
+            "version": "0.1.9",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "^2.7",
-                "prettier-plugin-motoko": "^0.1.8"
+                "prettier-plugin-motoko": "^0.1.9"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4638,9 +4638,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.8.tgz",
-            "integrity": "sha512-+OHrGiZH/J7nJmrz7SvOlAevcm5GGoK2kCpNWWnfMAcCepTGeBHJGEnn3fOA31EEdQnFL5mAATVIbeMzZU69Mg==",
+            "version": "0.1.9",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.9.tgz",
+            "integrity": "sha512-G20R8qykt3F1frGgasaQ/qGiK04Sz1QnxWkaoNUmkC6tbTDsIrESk+FC2WigBbA7skyFYVdETG+9InKNORS6pA==",
             "peerDependencies": {
                 "prettier": "^2.7"
             }
@@ -9286,9 +9286,9 @@
             "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.8.tgz",
-            "integrity": "sha512-+OHrGiZH/J7nJmrz7SvOlAevcm5GGoK2kCpNWWnfMAcCepTGeBHJGEnn3fOA31EEdQnFL5mAATVIbeMzZU69Mg==",
+            "version": "0.1.9",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.9.tgz",
+            "integrity": "sha512-G20R8qykt3F1frGgasaQ/qGiK04Sz1QnxWkaoNUmkC6tbTDsIrESk+FC2WigBbA7skyFYVdETG+9InKNORS6pA==",
             "requires": {}
         },
         "pretty-format": {

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -21,7 +21,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "^2.7",
-        "prettier-plugin-motoko": "^0.1.9"
+        "prettier-plugin-motoko": "^0.1.10"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -21,7 +21,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "^2.7",
-        "prettier-plugin-motoko": "^0.1.8"
+        "prettier-plugin-motoko": "^0.1.9"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -160,6 +160,13 @@ function printTokenTree(
                 return true;
             }
             if (groupType === 'Square' || groupType === 'Paren') {
+                if (
+                    trees.length === 1 &&
+                    trees[0].token_tree_type === 'Group'
+                ) {
+                    // allow wrapping for nested groups such as `((a, b, ...))`
+                    return false;
+                }
                 return results.length <= 1 && !shouldBreak;
             }
             return false;
@@ -251,6 +258,7 @@ function printTokenTree(
                     );
                 } else if (results.length || resultGroup.length) {
                     endGroup();
+
                     // Trailing delimiter
                     if (
                         (!isSeparator || isDelim) &&

--- a/src/printers/motoko-tt-ast/utils.ts
+++ b/src/printers/motoko-tt-ast/utils.ts
@@ -4,7 +4,7 @@ import { Doc } from 'prettier';
 /// Get the unmodified source text from a TokenTree
 export function getTokenTreeText(tree: TokenTree): string {
     if (tree.token_tree_type === 'Group') {
-        const [trees, groupType, pair] = tree.data;
+        const [trees, _, pair] = tree.data;
         const results = trees.map((tt: TokenTree) => getTokenTreeText(tt));
         return (
             pair

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -104,17 +104,19 @@ describe('Motoko formatter', () => {
             .fill(['\n  ' + 'x'.repeat(20)])
             .join(',')},\n);\n`;
         expect(format(wrapped)).toStrictEqual(wrapped);
+    });
 
+    test('nested group line breaks', () => {
         expect(
             format(
-                `((${Array(5)
+                `(\n(${Array(5)
                     .fill(['\n' + 'x'.repeat(20)])
                     .join(', ')}));\n`,
             ),
         ).toStrictEqual(
-            `(\n  (${Array(5)
-                .fill(['\n    ' + 'x'.repeat(20)])
-                .join(',')},\n  ),\n);\n`,
+            `((${Array(5)
+                .fill(['\n  ' + 'x'.repeat(20)])
+                .join(',')},\n));\n`,
         );
     });
 

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -99,6 +99,25 @@ describe('Motoko formatter', () => {
         );
     });
 
+    test('tuple line breaks', () => {
+        const wrapped = `(${Array(5)
+            .fill(['\n  ' + 'x'.repeat(20)])
+            .join(',')},\n);\n`;
+        expect(format(wrapped)).toStrictEqual(wrapped);
+
+        expect(
+            format(
+                `((${Array(5)
+                    .fill(['\n' + 'x'.repeat(20)])
+                    .join(', ')}));\n`,
+            ),
+        ).toStrictEqual(
+            `(\n  (${Array(5)
+                .fill(['\n    ' + 'x'.repeat(20)])
+                .join(',')},\n  ),\n);\n`,
+        );
+    });
+
     test('type binding line breaks', () => {
         const parens = `<(${Array(5)
             .fill(['x'.repeat(20)])

--- a/tests/motoko.test.ts
+++ b/tests/motoko.test.ts
@@ -199,6 +199,18 @@ describe('Motoko formatter', () => {
         // );
     });
 
+    test('unclosed quotes in comments', () => {
+        expect(format("// a'b\n '")).toStrictEqual("// a'b\n';\n");
+        expect(format('// a"b\n "')).toStrictEqual('// a"b\n";\n');
+        expect(format("//'\n '")).toStrictEqual("//'\n';\n");
+        expect(format('//"\n "')).toStrictEqual('//"\n";\n');
+
+        expect(format("/*'*/  '")).toStrictEqual("/*'*/ '\n");
+        // expect(format('/*"*/  "')).toStrictEqual('/*\n"*/ "\n');
+        expect(format("/* a'b */  '")).toStrictEqual("/* a'b */\n';\n");
+        // expect(format('/* a"b */  "')).toStrictEqual('/* a"b */\n";\n');
+    });
+
     // test('generate diff files from compiler tests', () => {
     //     for (const extension of ['mo', 'did']) {
     //         let preOutput = '';

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,7 +15,7 @@ default = ["console_error_panic_hook"]
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
-motoko = { path = "../../motoko.rs" }
+motoko = "0.0.16"
 
 console_error_panic_hook = { version = "0.1.6", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -18,7 +18,6 @@ wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
 motoko = "0.0.16"
 
 console_error_panic_hook = { version = "0.1.6", optional = true }
-wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -2,12 +2,6 @@ use motoko::lexer::create_token_tree;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 #[wasm_bindgen]
 extern "C" {
     // fn alert(s: &str);


### PR DESCRIPTION
Enables line wrapping for tuples and arrays with a single tuple or array element, such as `((a, b, ...))`.
