### PR TITLE
Automatically insert semicolons after multi-line blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.2.7",
+    "version": "0.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.2.7",
+            "version": "0.3.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5125,9 +5125,9 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+            "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
             "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
@@ -11246,9 +11246,9 @@
             "dev": true
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+            "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
             "dev": true
         },
         "jsonfile": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.2.7",
+    "version": "0.3.0",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.2.7",
+    "version": "0.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.2.7",
+            "version": "0.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "^2.7",
-                "prettier-plugin-motoko": "^0.2.7"
+                "prettier-plugin-motoko": "^0.3.0"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -3619,9 +3619,9 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+            "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
             "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
@@ -4638,9 +4638,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.7.tgz",
-            "integrity": "sha512-T/ZwvPu0i2RFjJqewvwpoKp2SxqPQecaAANo1PSfOdgALVgsaxajMvnHJbLHGUsi3tZj/2SFErFtoTZtn6lE8A==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.0.tgz",
+            "integrity": "sha512-mNNJv08YkCFXK9zXeUjvMct26+XXElZgei8m3lkhsKEd6DfpeCRV0CrdfN87h0FLVOBcWu6O+i9KyCrprQ1DXg==",
             "peerDependencies": {
                 "prettier": "^2.7"
             }
@@ -8534,9 +8534,9 @@
             "dev": true
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+            "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
             "dev": true
         },
         "jsonfile": {
@@ -9286,9 +9286,9 @@
             "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.7.tgz",
-            "integrity": "sha512-T/ZwvPu0i2RFjJqewvwpoKp2SxqPQecaAANo1PSfOdgALVgsaxajMvnHJbLHGUsi3tZj/2SFErFtoTZtn6lE8A==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.0.tgz",
+            "integrity": "sha512-mNNJv08YkCFXK9zXeUjvMct26+XXElZgei8m3lkhsKEd6DfpeCRV0CrdfN87h0FLVOBcWu6O+i9KyCrprQ1DXg==",
             "requires": {}
         },
         "pretty-format": {

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.2.7",
+    "version": "0.3.0",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -21,7 +21,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "^2.7",
-        "prettier-plugin-motoko": "^0.2.7"
+        "prettier-plugin-motoko": "^0.3.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",

--- a/src/parsers/motoko-tt-parse/parse.ts
+++ b/src/parsers/motoko-tt-parse/parse.ts
@@ -1,4 +1,6 @@
+import { ParserOptions } from 'prettier';
 import wasm from '../../wasm';
+import preprocess from './preprocess';
 
 type Loc<T> = [T, Source];
 
@@ -79,11 +81,11 @@ export type Source = {
 export default function parse(
     text: string,
     parsers: object,
-    options: object,
+    options: ParserOptions<any>,
 ): TokenTree {
-    let tt = wasm.parse_token_tree(text.trim());
+    text = preprocess(text, options);
 
+    const tt = wasm.parse_token_tree(text.trim());
     // console.log(tt);
-
     return tt;
 }

--- a/src/parsers/motoko-tt-parse/preprocess.ts
+++ b/src/parsers/motoko-tt-parse/preprocess.ts
@@ -1,0 +1,51 @@
+import { ParserOptions } from 'prettier';
+
+const LINE_COMMENT = '//';
+
+export default function preprocess(
+    code: string,
+    options: ParserOptions<any>,
+): string {
+    code = code.replace(/\t/g, ' '.repeat(options.tabWidth));
+
+    if (options.semi) {
+        // Infer semicolons
+        let nextIndent = 0;
+        const reversedLines = code.split('\n').reverse();
+        code = reversedLines
+            .map((line: string, i: number) => {
+                const trimmedLine = line.trim();
+                if (!trimmedLine) {
+                    return line;
+                }
+                // if (trimmedLine.startsWith(LINE_COMMENT)) {
+                //     const comment = trimmedLine
+                //         .substring(LINE_COMMENT.length)
+                //         .trim();
+                //     return line;
+                // }
+
+                let indent = 0;
+                while (indent < line.length && line.charAt(indent) === ' ') {
+                    indent++;
+                }
+
+                const nextTrimmedLine = (reversedLines[i - 1] || '').trim();
+                // const previousTrimmedLine = (lines[i + 1] || '').trim();
+
+                if (
+                    trimmedLine === '}' &&
+                    !/^(else|catch)([^a-zA-Z0-9_]|$)/.test(nextTrimmedLine)
+                ) {
+                    line += ';';
+                }
+
+                nextIndent = indent;
+                return line;
+            })
+            .reverse()
+            .join('\n');
+    }
+
+    return code;
+}

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -38,7 +38,7 @@ describe('Motoko formatter', () => {
 
     test('line comments', () => {
         expect(format('{//\n}//')).toStrictEqual('{\n  //\n} //\n');
-        expect(format('{\n//\n}\n//')).toStrictEqual('{\n  //\n}\n//\n');
+        expect(format('{\n//\n}\n//')).toStrictEqual('{\n  //\n};\n//\n');
         expect(format('//a\n//b')).toStrictEqual('//a\n//b\n');
         expect(format('//a\n\n\n//b')).toStrictEqual('//a\n\n//b\n');
     });

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -317,6 +317,11 @@ describe('Motoko formatter', () => {
         expect(format('0.\ny')).toStrictEqual('0.\ny;\n');
     });
 
+    test('automatic semicolons', () => {
+        expect(format('{\n}\nA\n')).toStrictEqual('{};\nA;\n');
+        expect(format('{\n// }\n}\nA\n')).toStrictEqual('{\n  // }\n};\nA;\n');
+    });
+
     // test('generate diff files from compiler tests', () => {
     //     for (const extension of ['mo', 'did']) {
     //         let preOutput = '';


### PR DESCRIPTION
This PR includes parts of the automatic semicolon insertion logic from [Embed Motoko](https://github.com/dfinity/embed-motoko). 

This feature is enabled by default and can be deactivated by adding `"semi": false` to your `.prettierrc` file ([more info](https://prettier.io/docs/en/configuration.html)). 