### PR TITLE
Fix trailing semicolon corner case

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - run: git clone https://github.com/dfinity/motoko.git ../motoko --depth 1
     - run: npm ci
     - run: npm i prettier
     - run: npm run build --if-present

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.3.4",
+            "version": "0.3.5",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.3.5",
+            "version": "0.3.6",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.3.4",
+            "version": "0.3.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "^2.7",
-                "prettier-plugin-motoko": "^0.3.4"
+                "prettier-plugin-motoko": "^0.3.5"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4654,9 +4654,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.4.tgz",
-            "integrity": "sha512-Yb6wxFOvBhf3Sd5l9Pq+L0hfyEIeo8SfJ2ohSgLuJ8cJ71MiJ8EI5+/yCuBBCup2FmKGsVAOMrLUFdLZwfftQg==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.5.tgz",
+            "integrity": "sha512-ooEYebiaRtidYCYrouA4jwSRNngeJITloDhArsKG9oAgC0Qaz4kyhotHtACOfJegaiEF2YIibDKaQuHs4Qu/QA==",
             "peerDependencies": {
                 "prettier": "^2.7"
             }
@@ -9313,9 +9313,9 @@
             "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.4.tgz",
-            "integrity": "sha512-Yb6wxFOvBhf3Sd5l9Pq+L0hfyEIeo8SfJ2ohSgLuJ8cJ71MiJ8EI5+/yCuBBCup2FmKGsVAOMrLUFdLZwfftQg==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.5.tgz",
+            "integrity": "sha512-ooEYebiaRtidYCYrouA4jwSRNngeJITloDhArsKG9oAgC0Qaz4kyhotHtACOfJegaiEF2YIibDKaQuHs4Qu/QA==",
             "requires": {}
         },
         "pretty-format": {

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -21,7 +21,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "^2.7",
-        "prettier-plugin-motoko": "^0.3.4"
+        "prettier-plugin-motoko": "^0.3.5"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -342,7 +342,8 @@ function printTokenTree(
                         (groupType !== 'Paren' || results.length > 1) &&
                         (groupType === 'Unenclosed' || groupType === 'Curly'
                             ? options.semi
-                            : options.trailingComma !== 'none') &&
+                            : options.trailingComma &&
+                              options.trailingComma !== 'none') &&
                         !isPossiblyRecordExtension() &&
                         !(
                             groupType === 'Square' &&

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -339,6 +339,7 @@ function printTokenTree(
                         (!isSeparator || isDelim) &&
                         !hasNestedGroup &&
                         !shouldKeepSameLine() &&
+                        (groupType !== 'Paren' || results.length > 1) &&
                         (groupType === 'Unenclosed' || groupType === 'Curly'
                             ? options.semi
                             : options.trailingComma !== 'none') &&

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -258,6 +258,7 @@ function printTokenTree(
         const results: Doc[] = [];
         let resultGroup: Doc[] = [];
         let ignoringNextStatement = false;
+        let allowTrailingSeparator = false;
         const endGroup = () => {
             if (resultGroup.length) {
                 results.push(fill(resultGroup));
@@ -292,15 +293,20 @@ function printTokenTree(
                 }
             }
 
+            // allow trailing delimiter for everything except comments
+            if (comment === undefined) {
+                // allow trailing comma/semicolon if something exists in the group other than a comment
+                allowTrailingSeparator = true;
+            }
             // check for prettier-ignore comments
-            if (comment) {
-                if (comment === 'prettier-ignore') {
-                    ignoringNextStatement = true;
-                }
+            else if (comment === 'prettier-ignore') {
+                ignoringNextStatement = true;
             }
 
             if (isSeparator) {
                 endGroup();
+                // reset to default
+                allowTrailingSeparator = false;
             }
 
             if (ignoringNextStatement) {
@@ -336,6 +342,9 @@ function printTokenTree(
 
                     // trailing delimiter
                     if (
+                        (allowTrailingSeparator ||
+                            !results.length ||
+                            isDelim) &&
                         (!isSeparator || isDelim) &&
                         !hasNestedGroup &&
                         !shouldKeepSameLine() &&

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -322,7 +322,7 @@ function printTokenTree(
                 // add everything except trailing delimiter
                 if (!isDelim || i !== trees.length - 1) {
                     resultArray.push(
-                        isDelim 
+                        isDelim
                             ? printToken(getGroupDelimToken(groupType))
                             : printTokenTree(a, path, options, print, args),
                     );
@@ -342,7 +342,12 @@ function printTokenTree(
                         (groupType === 'Unenclosed' || groupType === 'Curly'
                             ? options.semi
                             : options.trailingComma !== 'none') &&
-                        !isPossiblyRecordExtension()
+                        !isPossiblyRecordExtension() &&
+                        !(
+                            groupType === 'Square' &&
+                            results.length === 1 &&
+                            !isSeparator
+                        ) // possibly array type
                     ) {
                         results.push(
                             ifBreak(printToken(getGroupDelimToken(groupType))),

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -2,7 +2,7 @@ import prettier from 'prettier';
 import * as motokoPlugin from '../src/environments/node';
 import glob from 'fast-glob';
 import { join, basename } from 'path';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 
 const prettierOptions: prettier.Options = {
     plugins: [motokoPlugin],
@@ -12,9 +12,6 @@ const prettierOptions: prettier.Options = {
 const format = (input: string, options?: prettier.Options): string => {
     return prettier.format(input, { ...prettierOptions, ...options });
 };
-
-const expectFormatted = (input: string) =>
-    expect(format(input)).toStrictEqual(input);
 
 describe('Motoko compiler suite', () => {
     test('generate diff files from compiler tests', () => {
@@ -35,12 +32,16 @@ describe('Motoko compiler suite', () => {
                     file,
                 )} <<<\n\n${formatted}\n\n`;
             }
+            const generatedDir = join(__dirname, 'generated');
+            if (!existsSync(generatedDir)) {
+                mkdirSync(generatedDir);
+            }
             writeFileSync(
-                join(__dirname, `generated/_CompilerTests_Before.${extension}_`),
+                join(generatedDir, `_CompilerTests_Before.${extension}_`),
                 preOutput,
             );
             writeFileSync(
-                join(__dirname, `generated/_CompilerTests_Formatted.${extension}_`),
+                join(generatedDir, `_CompilerTests_Formatted.${extension}_`),
                 postOutput,
             );
         }

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -1,0 +1,48 @@
+import prettier from 'prettier';
+import * as motokoPlugin from '../src/environments/node';
+import glob from 'fast-glob';
+import { join, basename } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+
+const prettierOptions: prettier.Options = {
+    plugins: [motokoPlugin],
+    filepath: 'Main.mo',
+};
+
+const format = (input: string, options?: prettier.Options): string => {
+    return prettier.format(input, { ...prettierOptions, ...options });
+};
+
+const expectFormatted = (input: string) =>
+    expect(format(input)).toStrictEqual(input);
+
+describe('Motoko compiler suite', () => {
+    test('generate diff files from compiler tests', () => {
+        for (const extension of ['mo', 'did']) {
+            let preOutput = '';
+            let postOutput = '';
+            for (const file of glob.sync(
+                join(__dirname, `../../motoko/test/**/*.${extension}`),
+            )) {
+                const code = readFileSync(file, 'utf-8');
+                const formatted = prettier.format(code, {
+                    filepath: file,
+                    plugins: [motokoPlugin],
+                    // semi: false,///
+                });
+                preOutput += `// >>> ${basename(file)} <<<\n\n${code}\n\n`;
+                postOutput += `// >>> ${basename(
+                    file,
+                )} <<<\n\n${formatted}\n\n`;
+            }
+            writeFileSync(
+                join(__dirname, `generated/_CompilerTests_Before.${extension}_`),
+                preOutput,
+            );
+            writeFileSync(
+                join(__dirname, `generated/_CompilerTests_Formatted.${extension}_`),
+                postOutput,
+            );
+        }
+    });
+});

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -274,7 +274,7 @@ describe('Motoko formatter', () => {
             `${'x'.repeat(80)}[0];\n`,
         );
         expect(format(`${'x'.repeat(80)}[\n0]`)).toStrictEqual(
-            `${'x'.repeat(80)}[\n  0,\n];\n`,
+            `${'x'.repeat(80)}[\n  0\n];\n`,
         );
         expect(format(`${'x'.repeat(80)}[0,]`)).toStrictEqual(
             `${'x'.repeat(80)}[0];\n`,
@@ -340,6 +340,12 @@ describe('Motoko formatter', () => {
 
     test('quote literals', () => {
         expect(format("'\\\"'; //abc")).toStrictEqual("'\\\"'; //abc\n");
+    });
+
+    test('trailing comma in square brackets', () => {
+        expect(format("[\na,b]")).toStrictEqual("[\n  a,\n  b,\n];\n");
+        expect(format("[\na,]")).toStrictEqual("[\n  a,\n];\n");
+        expect(format("x : [\nT\n]")).toStrictEqual("x : [\n  T\n];\n");
     });
 
     // test('generate diff files from compiler tests', () => {

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -348,32 +348,7 @@ describe('Motoko formatter', () => {
         expect(format("x : [\nT\n]")).toStrictEqual("x : [\n  T\n];\n");
     });
 
-    // test('generate diff files from compiler tests', () => {
-    //     for (const extension of ['mo', 'did']) {
-    //         let preOutput = '';
-    //         let postOutput = '';
-    //         for (const file of glob.sync(
-    //             join(__dirname, `../../motoko/test/**/*.${extension}`),
-    //         )) {
-    //             const code = readFileSync(file, 'utf-8');
-    //             const formatted = prettier.format(code, {
-    //                 filepath: file,
-    //                 plugins: [motokoPlugin],
-    //                 // semi: false,///
-    //             });
-    //             preOutput += `// >>> ${basename(file)} <<<\n\n${code}\n\n`;
-    //             postOutput += `// >>> ${basename(
-    //                 file,
-    //             )} <<<\n\n${formatted}\n\n`;
-    //         }
-    //         writeFileSync(
-    //             join(__dirname, `generated/_CompilerTests_Before.${extension}_`),
-    //             preOutput,
-    //         );
-    //         writeFileSync(
-    //             join(__dirname, `generated/_CompilerTests_Formatted.${extension}_`),
-    //             postOutput,
-    //         );
-    //     }
-    // });
+    test('trailing semicolon after block comment', () => {
+        expect(format("x;\n/*\n*/")).toStrictEqual("x;\n/*\n*/\n");
+    });
 });

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -50,7 +50,8 @@ describe('Motoko formatter', () => {
         expect(format('let/*{{*/x = 0;//x\n (x)')).toStrictEqual(
             'let /*{{*/ x = 0; //x\n(x);\n',
         );
-        expect(format('\n/**/\n\n\n/**/')).toStrictEqual('/**/\n\n/**/;\n');
+        expect(format('/**//**/')).toStrictEqual('/**/ /**/\n');
+        expect(format('\n/**/\n\n\n/**/')).toStrictEqual('/**/\n\n/**/\n');
         expectFormatted('/*=*/\n');
         expectFormatted('/**=*/\n');
         expectFormatted('/**=**/\n');
@@ -353,6 +354,7 @@ describe('Motoko formatter', () => {
     });
 
     test('trailing semicolon after block comment', () => {
+        expect(format("x;\n/**/")).toStrictEqual("x;\n/**/\n");
         expect(format("x;\n/*\n*/")).toStrictEqual("x;\n/*\n*/\n");
     });
 });

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -172,7 +172,7 @@ describe('Motoko formatter', () => {
         expect(format('().0')).toStrictEqual('().0\n');
         // expect(format('(\n).0')).toStrictEqual('().0\n');
         expect(format('(\n\n\n).0')).toStrictEqual('().0\n');
-        expect(format('(\na\n).0')).toStrictEqual('(\n  a,\n).0;\n');
+        expect(format('(\na\n).0')).toStrictEqual('(\n  a\n).0;\n');
     });
 
     // test('cursor position', () => {
@@ -286,7 +286,7 @@ describe('Motoko formatter', () => {
 
     test('anonymous function line break', () => {
         expect(format('(func() {\na\n})')).toStrictEqual(
-            '(\n  func() {\n    a;\n  },\n);\n',
+            '(\n  func() {\n    a;\n  }\n);\n',
         );
     });
 
@@ -346,6 +346,10 @@ describe('Motoko formatter', () => {
         expect(format("[\na,b]")).toStrictEqual("[\n  a,\n  b,\n];\n");
         expect(format("[\na,]")).toStrictEqual("[\n  a,\n];\n");
         expect(format("x : [\nT\n]")).toStrictEqual("x : [\n  T\n];\n");
+    });
+
+    test('comma-parentheses', () => {
+        expect(format('if(\nx) { y }')).toStrictEqual('if (\n  x\n) { y };\n');
     });
 
     test('trailing semicolon after block comment', () => {


### PR DESCRIPTION
Fixes a corner case involving a trailing semicolon after a block comment at the end of a file.