### PR TITLE
Allow multi-line text concatenation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.4.3",
+    "version": "0.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.4.3",
+            "version": "0.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.4.3",
+    "version": "0.5.0",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.4.3",
+    "version": "0.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.4.3",
+            "version": "0.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "^2.7",
-                "prettier-plugin-motoko": "^0.4.3"
+                "prettier-plugin-motoko": "^0.5.0"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4684,9 +4684,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.4.3.tgz",
-            "integrity": "sha512-o1rF9YxYoYFQbHJfcRMosRygngbjDuhkaHu1WCgPRwdZwXAzGh84Jaj6PiVFnCa+EU97Jt/gTph3GTgzl4kFTQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.5.0.tgz",
+            "integrity": "sha512-2k8sIRuCE/OYQFXSsCr4Z4SY78zCyBNbp4kImsvhnCzfyMqgJpFDFFGAUNzrs18FShpSy8f2p1eOe+x7apIwMQ==",
             "dependencies": {
                 "out-of-character": "^1.2.1"
             },
@@ -9365,9 +9365,9 @@
             "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.4.3.tgz",
-            "integrity": "sha512-o1rF9YxYoYFQbHJfcRMosRygngbjDuhkaHu1WCgPRwdZwXAzGh84Jaj6PiVFnCa+EU97Jt/gTph3GTgzl4kFTQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.5.0.tgz",
+            "integrity": "sha512-2k8sIRuCE/OYQFXSsCr4Z4SY78zCyBNbp4kImsvhnCzfyMqgJpFDFFGAUNzrs18FShpSy8f2p1eOe+x7apIwMQ==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.4.3",
+    "version": "0.5.0",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -21,7 +21,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "^2.7",
-        "prettier-plugin-motoko": "^0.4.3"
+        "prettier-plugin-motoko": "^0.5.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -150,7 +150,6 @@ const spaceConfig: SpaceConfig = {
         [{ left: tokenEquals('do'), main: tokenEquals('?') }, '_', 'space'],
         // [tokenEquals('?'), 'Curly', 'keep'],
         [tokenEquals('?'), '_', 'nil'],
-        // [tokenEquals('#'), 'Ident', 'nil'], ///
         ['_', tokenEquals('!'), 'nil'],
 
         // space between identifier and group

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -128,10 +128,14 @@ const spaceConfig: SpaceConfig = {
         [{ left: tokenEquals('if'), main: '_' }, 'Paren', 'space'],
 
         // unary operators
-        [tokenEquals('#'), 'Ident', 'keep'],
         [tokenEquals('+'), '_', 'keep'],
         [tokenEquals('-'), '_', 'keep'],
         [tokenEquals('^'), '_', 'keep'],
+        // [tokenEquals('#'), 'Ident', 'keep'],
+
+        // tags and concatenation
+        [tokenEquals('#'), '_', 'keep'],
+        ['_', tokenEquals('#'), 'keep'],
 
         // 'with' keyword
         [tokenEquals('with'), '_', 'keep-space'],

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -95,8 +95,12 @@ describe('Motoko formatter', () => {
         expect(format('# "A"')).toStrictEqual('# "A"\n');
         expect(format('# 5')).toStrictEqual('# 5\n');
         expect(format('#a')).toStrictEqual('#a\n');
-        expect(format('"A"# b')).toStrictEqual('"A" # b\n');
-        expect(format('"A"# #b')).toStrictEqual('"A" # #b\n');
+        expect(format('"A" # b')).toStrictEqual('"A" # b\n');
+        expect(format('"A" # #b')).toStrictEqual('"A" # #b\n');
+        // expect(format('"A"# b')).toStrictEqual('"A" # b\n');
+        // expect(format('"A"#"B"')).toStrictEqual('"A" # "B"\n');
+        // expect(format('"A"# #b')).toStrictEqual('"A" # #b\n');
+        expect(format('"A" #\n"B"')).toStrictEqual('"A" #\n"B";\n');
     });
 
     test('do ? / optional', () => {


### PR DESCRIPTION
Provides more flexibility for the text concatenation operator. 

Recommended pattern:

```motoko
let text = (
  "aaa" #
  "bbb" #
  "ccc"
);
// Result: "aaabbbccc"
```

Fixes #68.
