### PR TITLE
Reintroduce support for Webpack 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "ts-jest": "^28.0.8",
                 "ts-node": "^10.9.1",
                 "typescript": "^4.8.2",
-                "wasm-pack": "^0.10.3"
+                "wasm-pack": "^0.11.1"
             },
             "peerDependencies": {
                 "prettier": "^2.7"
@@ -1632,12 +1632,12 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
             "dev": true,
             "dependencies": {
-                "follow-redirects": "^1.14.0"
+                "follow-redirects": "^1.14.8"
             }
         },
         "node_modules/babel-jest": {
@@ -1827,14 +1827,14 @@
             ]
         },
         "node_modules/binary-install": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.1.1.tgz",
-            "integrity": "sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.1.0.tgz",
+            "integrity": "sha512-rkwNGW+3aQVSZoD0/o3mfPN6Yxh3Id0R/xzTVBVVpGNlVz8EGwusksxRlbk/A5iKTZt9zkMn3qIqmAt3vpfbzg==",
             "dev": true,
             "dependencies": {
-                "axios": "^0.21.1",
+                "axios": "^0.26.1",
                 "rimraf": "^3.0.2",
-                "tar": "^6.1.0"
+                "tar": "^6.1.11"
             },
             "engines": {
                 "node": ">=10"
@@ -2036,13 +2036,10 @@
             }
         },
         "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "dev": true
         },
         "node_modules/ci-info": {
             "version": "3.3.2",
@@ -2604,9 +2601,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
             "dev": true,
             "funding": [
                 {
@@ -2664,6 +2661,18 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/fs.realpath": {
@@ -5353,13 +5362,10 @@
             "dev": true
         },
         "node_modules/minipass": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-            "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
             "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
             "engines": {
                 "node": ">=8"
             }
@@ -5375,6 +5381,18 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/mkdirp": {
@@ -6855,20 +6873,20 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.1.11",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+            "version": "6.1.15",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+            "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
             "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=10"
             }
         },
         "node_modules/tar-fs": {
@@ -6882,12 +6900,6 @@
                 "pump": "^3.0.0",
                 "tar-stream": "^2.1.4"
             }
-        },
-        "node_modules/tar-fs/node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
         },
         "node_modules/tar-stream": {
             "version": "2.2.0",
@@ -6917,6 +6929,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/tar/node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/terminal-link": {
@@ -7255,13 +7276,13 @@
             }
         },
         "node_modules/wasm-pack": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.10.3.tgz",
-            "integrity": "sha512-dg1PPyp+QwWrhfHsgG12K/y5xzwfaAoK1yuVC/DUAuQsDy5JywWDuA7Y/ionGwQz+JBZVw8jknaKBnaxaJfwTA==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.11.1.tgz",
+            "integrity": "sha512-0BKEioKJY/SMqahDEoaUUR8jrRkHO0cdYhRqqHKQMY3Bac6Eep3ZRsTlpFSSwS4LYPxd+Tb5KFFNhUikCkq8Yg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "binary-install": "^0.1.0"
+                "binary-install": "^1.0.1"
             },
             "bin": {
                 "wasm-pack": "run.js"
@@ -8714,12 +8735,12 @@
             "dev": true
         },
         "axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.14.0"
+                "follow-redirects": "^1.14.8"
             }
         },
         "babel-jest": {
@@ -8855,14 +8876,14 @@
             "dev": true
         },
         "binary-install": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.1.1.tgz",
-            "integrity": "sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.1.0.tgz",
+            "integrity": "sha512-rkwNGW+3aQVSZoD0/o3mfPN6Yxh3Id0R/xzTVBVVpGNlVz8EGwusksxRlbk/A5iKTZt9zkMn3qIqmAt3vpfbzg==",
             "dev": true,
             "requires": {
-                "axios": "^0.21.1",
+                "axios": "^0.26.1",
                 "rimraf": "^3.0.2",
-                "tar": "^6.1.0"
+                "tar": "^6.1.11"
             }
         },
         "bl": {
@@ -8999,9 +9020,9 @@
             "dev": true
         },
         "chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "dev": true
         },
         "ci-info": {
@@ -9441,9 +9462,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
             "dev": true
         },
         "from2": {
@@ -9481,6 +9502,17 @@
             "dev": true,
             "requires": {
                 "minipass": "^3.0.0"
+            },
+            "dependencies": {
+                "minipass": {
+                    "version": "3.3.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                }
             }
         },
         "fs.realpath": {
@@ -11446,13 +11478,10 @@
             "dev": true
         },
         "minipass": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-            "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-            "dev": true,
-            "requires": {
-                "yallist": "^4.0.0"
-            }
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true
         },
         "minizlib": {
             "version": "2.1.2",
@@ -11462,6 +11491,17 @@
             "requires": {
                 "minipass": "^3.0.0",
                 "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "minipass": {
+                    "version": "3.3.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                }
             }
         },
         "mkdirp": {
@@ -12542,17 +12582,25 @@
             "dev": true
         },
         "tar": {
-            "version": "6.1.11",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+            "version": "6.1.15",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+            "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
             "dev": true,
             "requires": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+                    "dev": true
+                }
             }
         },
         "tar-fs": {
@@ -12565,14 +12613,6 @@
                 "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
                 "tar-stream": "^2.1.4"
-            },
-            "dependencies": {
-                "chownr": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-                    "dev": true
-                }
             }
         },
         "tar-stream": {
@@ -12823,12 +12863,12 @@
             }
         },
         "wasm-pack": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.10.3.tgz",
-            "integrity": "sha512-dg1PPyp+QwWrhfHsgG12K/y5xzwfaAoK1yuVC/DUAuQsDy5JywWDuA7Y/ionGwQz+JBZVw8jknaKBnaxaJfwTA==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.11.1.tgz",
+            "integrity": "sha512-0BKEioKJY/SMqahDEoaUUR8jrRkHO0cdYhRqqHKQMY3Bac6Eep3ZRsTlpFSSwS4LYPxd+Tb5KFFNhUikCkq8Yg==",
             "dev": true,
             "requires": {
-                "binary-install": "^0.1.0"
+                "binary-install": "^1.0.1"
             }
         },
         "webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.5.2",
+            "version": "0.5.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "ts-jest": "^28.0.8",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.2",
-        "wasm-pack": "^0.10.3"
+        "wasm-pack": "^0.11.1"
     },
     "peerDependencies": {
         "prettier": "^2.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.5.2",
+            "version": "0.5.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "^2.7",
-                "prettier-plugin-motoko": "^0.5.2"
+                "prettier-plugin-motoko": "^0.5.3"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4684,9 +4684,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.5.2.tgz",
-            "integrity": "sha512-0KjHdFqeJDFcf1Z4dB7dbAWjfCZIo6J/X/ONGMyOq85mDh0eg6exB3nRVXvCz7wIOY49ZlQEZZIAnmJqEW3+dA==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.5.3.tgz",
+            "integrity": "sha512-f/myF9W9Jpir8rIp97iE+3ebrE0pq1Oi0+ffntdjzNecQSWHbyopUm5GY05gaS42oZWDFkHwQKg7MIl+fl9eyw==",
             "dependencies": {
                 "out-of-character": "^1.2.1"
             },
@@ -9365,9 +9365,9 @@
             "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.5.2.tgz",
-            "integrity": "sha512-0KjHdFqeJDFcf1Z4dB7dbAWjfCZIo6J/X/ONGMyOq85mDh0eg6exB3nRVXvCz7wIOY49ZlQEZZIAnmJqEW3+dA==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.5.3.tgz",
+            "integrity": "sha512-f/myF9W9Jpir8rIp97iE+3ebrE0pq1Oi0+ffntdjzNecQSWHbyopUm5GY05gaS42oZWDFkHwQKg7MIl+fl9eyw==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -21,7 +21,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "^2.7",
-        "prettier-plugin-motoko": "^0.5.2"
+        "prettier-plugin-motoko": "^0.5.3"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",

--- a/tests/test-webapp/package-lock.json
+++ b/tests/test-webapp/package-lock.json
@@ -23,9 +23,11 @@
       }
     },
     "../..": {
-      "name": "prettier-plugin-motoko",
-      "version": "0.3.0",
+      "version": "0.5.2",
       "license": "Apache-2.0",
+      "dependencies": {
+        "out-of-character": "^1.2.1"
+      },
       "devDependencies": {
         "@types/jest": "^28.1.7",
         "@types/prettier": "^2.7.0",
@@ -2292,6 +2294,7 @@
         "fast-glob": "^3.2.11",
         "jest": "^28.1.3",
         "npm-run-all": "^4.1.5",
+        "out-of-character": "^1.2.1",
         "pkg": "^5.8.0",
         "ts-jest": "^28.0.8",
         "ts-node": "^10.9.1",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -13,8 +13,8 @@ default = ["console_error_panic_hook"]
 [dependencies]
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
-wasm-bindgen = { version = "0.2.82" }
-serde-wasm-bindgen = "0.4.5"
+wasm-bindgen = { version = "=0.2.82" }
+serde-wasm-bindgen = "=0.4.3"
 motoko = "0.0.26"
 
 console_error_panic_hook = { version = "0.1.6", optional = true }


### PR DESCRIPTION
Uses an earlier version of `wasm-bindgen` to support loading in Webpack 4 environments such as the [Motoko Playground](https://m7sm4-2iaaa-aaaab-qabra-cai.ic0.app/). 