### PR TITLE
Implement automatic semicolon insertion with block comment and multi-line text awareness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.7.1",
+    "version": "0.8.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.7.1",
+            "version": "0.8.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.7.1",
+    "version": "0.8.0",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.7.1",
+    "version": "0.8.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.7.1",
+            "version": "0.8.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "^3.0",
-                "prettier-plugin-motoko": "^0.7.1"
+                "prettier-plugin-motoko": "^0.8.0"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4591,9 +4591,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.7.1.tgz",
-            "integrity": "sha512-9GuILLlop4Gjx94NRuGej5ihZ8rSebv0W+sY7bmDVA2GCe3A9iMk2tzW0OdoUprWAIsmxbJZCyYXF6aqZPaN5Q==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.8.0.tgz",
+            "integrity": "sha512-XJXjJbJ+hrjvEtfcvEcX1BMKC9iB8QH/lSEg2IlLjjTi29JyFBXVTZApjOuKPpLvju3QvZkyIMhjh85xyuVoHw==",
             "dependencies": {
                 "out-of-character": "^1.2.1"
             },
@@ -9152,9 +9152,9 @@
             "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.7.1.tgz",
-            "integrity": "sha512-9GuILLlop4Gjx94NRuGej5ihZ8rSebv0W+sY7bmDVA2GCe3A9iMk2tzW0OdoUprWAIsmxbJZCyYXF6aqZPaN5Q==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.8.0.tgz",
+            "integrity": "sha512-XJXjJbJ+hrjvEtfcvEcX1BMKC9iB8QH/lSEg2IlLjjTi29JyFBXVTZApjOuKPpLvju3QvZkyIMhjh85xyuVoHw==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.7.1",
+    "version": "0.8.0",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -22,7 +22,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "^3.0",
-        "prettier-plugin-motoko": "^0.7.1"
+        "prettier-plugin-motoko": "^0.8.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",

--- a/src/parsers/motoko-tt-parse/preprocess.ts
+++ b/src/parsers/motoko-tt-parse/preprocess.ts
@@ -1,5 +1,47 @@
 import { ParserOptions } from 'prettier';
 import outOfCharacter from 'out-of-character';
+import wasm from '../../wasm';
+
+function getLineIndices(code: string): number[] {
+    const indices = [];
+    for (let i = 0; i < code.length; i++) {
+        if (code[i] === '\n') {
+            indices.push(i);
+        }
+    }
+    return indices;
+}
+
+function findStringLiterals(code: string) {
+    const literals = [];
+    let inString = false;
+    let start = 0;
+    for (let i = 0; i < code.length; i++) {
+        if (code[i] === '"' && (i === 0 || code[i - 1] !== '\\')) {
+            if (inString) {
+                literals.push([start, i]);
+                inString = false;
+            } else {
+                inString = true;
+                start = i;
+            }
+        }
+    }
+    return literals;
+}
+
+// Replace the given spans with space characters
+function maskSpans(code: string, spans: [number, number][]) {
+    let result = '';
+    let currentIndex = 0;
+    for (const [start, end] of spans) {
+        result += code.substring(currentIndex, start);
+        result += code.substring(start, end).replace(/[^\s]/g, ' ');
+        currentIndex = end;
+    }
+    result += code.substring(currentIndex);
+    return result;
+}
 
 export default function preprocess(
     code: string,
@@ -9,37 +51,60 @@ export default function preprocess(
     code = code.replace(/[ \t]+(?=\r?\n)/g, ''); // remove trailing spaces
     code = outOfCharacter.replace(code); // remove invisible unicode characters
 
-    // if (options.semi) {
-    //     // Infer semicolons
-    //     let nextIndent = 0;
-    //     const reversedLines = code.split('\n').reverse();
-    //     code = reversedLines
-    //         .map((line: string, i: number) => {
-    //             const trimmedLine = line.trim();
-    //             if (!trimmedLine) {
-    //                 return line;
-    //             }
+    if (options.semi) {
+        // Infer semicolons
+        const commentSpans: [number, number][] = wasm.find_comments(code);
+        const codeMaskedComments = maskSpans(code, commentSpans);
+        const stringLiteralSpans = findStringLiterals(codeMaskedComments);
+        const ignoreSpans = [...commentSpans, ...stringLiteralSpans];
+        const reversedLines = code.split('\n').reverse();
+        const reversedLinesMaskedComments = codeMaskedComments
+            .split('\n')
+            .reverse();
+        const reversedLineIndices = getLineIndices(code).reverse();
+        let nextIndent = 0;
+        code = reversedLines
+            .map((line, i) => {
+                const trimmedLine = line.trim();
+                if (!trimmedLine) {
+                    return line;
+                }
 
-    //             let indent = 0;
-    //             while (indent < line.length && line.charAt(indent) === ' ') {
-    //                 indent++;
-    //             }
+                let indent = 0;
+                while (indent < line.length && line.charAt(indent) === ' ') {
+                    indent++;
+                }
 
-    //             const nextTrimmedLine = (reversedLines[i - 1] || '').trim();
+                // Following line, comments replaced with whitespace, trimmed
+                const nextLineMaskedCommentsTrimmed = (
+                    reversedLinesMaskedComments[i - 1] || ''
+                ).trim();
+                const nextLineIndex = reversedLineIndices[i];
 
-    //             if (
-    //                 trimmedLine === '}' &&
-    //                 !/^(else|catch)([^a-zA-Z0-9_]|$)/.test(nextTrimmedLine)
-    //             ) {
-    //                 line += ';';
-    //             }
+                if (
+                    trimmedLine === '}' &&
+                    // Skip when part of a path expression
+                    !nextLineMaskedCommentsTrimmed.startsWith('.') &&
+                    // Skip first block for if/else, try/catch
+                    !/^(else|catch)([^a-zA-Z0-9_]|$)/.test(
+                        nextLineMaskedCommentsTrimmed,
+                    ) &&
+                    // Skip comments and string literals
+                    (nextLineIndex === undefined ||
+                        !ignoreSpans.some(
+                            ([start, end]) =>
+                                start <= nextLineIndex && nextLineIndex < end,
+                        ))
+                ) {
+                    line += ';';
+                }
 
-    //             nextIndent = indent;
-    //             return line;
-    //         })
-    //         .reverse()
-    //         .join('\n');
-    // }
+                nextIndent = indent;
+                return line;
+            })
+            .reverse()
+            .join('\n');
+    }
 
     return code;
 }

--- a/src/parsers/motoko-tt-parse/preprocess.ts
+++ b/src/parsers/motoko-tt-parse/preprocess.ts
@@ -79,7 +79,7 @@ export default function preprocess(
                 const nextLineMaskedCommentsTrimmed = (
                     reversedLinesMaskedComments[i - 1] || ''
                 ).trim();
-                const nextLineIndex = reversedLineIndices[i];
+                const nextLineIndex = reversedLineIndices[i - 1];
 
                 if (
                     trimmedLine === '}' &&

--- a/src/wasm.ts
+++ b/src/wasm.ts
@@ -1,23 +1,7 @@
-// const wasm =
-//     typeof window === 'undefined'
-//         ? require(String('../wasm/pkg/nodejs/wasm')) // Guard against bundling both wasm files
-//         : require('../wasm/pkg/bundler/wasm');
+type Wasm = any;
 
-// const wasm =
-//     typeof window === 'undefined'
-//         ? require(String('../wasm/pkg/nodejs/wasm')) // Guard against bundling both wasm files
-//         : require('../wasm/pkg/bundler/wasm');
-
-// export default wasm;
-
-// import * as wasm from '../wasm/pkg/bundler/wasm';
-
-// export default wasm;
-
-let wasm: any = {};
-
-export const setWasm = (newWasm: object) => {
+const wasm: Wasm = {};
+export const setWasm = (newWasm: Wasm) => {
     Object.assign(wasm, newWasm);
 };
-
 export default wasm;

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -350,6 +350,8 @@ describe('Motoko formatter', () => {
 
     test('automatic semicolons', async () => {
         expect(await format('{\n}\nA\n')).toStrictEqual('{};\nA;\n');
+        expect(await format('if () {\n}\nelse {}')).toStrictEqual('if () {} else {};\n');
+        expect(await format('{\n}\n.A')).toStrictEqual('{}.A;\n');
     });
 
     test('automatic semicolons with line comment', async () => {
@@ -365,12 +367,10 @@ describe('Motoko formatter', () => {
         expect(await format('{\n}\n/**/\nA\n')).toStrictEqual('{};\n/**/\nA;\n');
         expect(await format('{\n/**/\n}\nA\n')).toStrictEqual('{\n  /**/\n};\nA;\n');
         expect(await format('{\n}\n\n{\n}')).toStrictEqual('{};\n\n{};\n');
-        expect(await format('if () {\n}\nelse {}')).toStrictEqual('if () {} else {};\n');
-        expect(await format('if () {\n}\n /**/ else {}')).toStrictEqual('if () {}\n/**/ else {};\n');
-        expect(await format('try {\n}\n /**/ catch {}')).toStrictEqual('try {}\n/**/ catch {};\n');
-        expect(await format('try {\n}\n /**/ variable {}')).toStrictEqual('try {};\n/**/ variable {};\n');
-        expect(await format('{\n}\n.A')).toStrictEqual('{}.A;\n');
-        expect(await format('{\n}\n /**/ .A')).toStrictEqual('{}\n/**/ .A;\n');
+        expect(await format('if () {\n}\n /*c*/ else {}')).toStrictEqual('if () {}\n/*c*/ else {};\n');
+        expect(await format('try {\n}\n /*c*/ catch {}')).toStrictEqual('try {}\n/*c*/ catch {};\n');
+        expect(await format('try {\n}\n /*c*/ variable {}')).toStrictEqual('try {};\n/*c*/ variable {};\n');
+        expect(await format('{\n}\n /*c*/ .A')).toStrictEqual('{}\n/*c*/ .A;\n');
     });
 
     test('automatic semicolons with multi-line text', async () => {


### PR DESCRIPTION
Reintroduces automatic semicolon insertion after `}` tokens whenever possible via a preprocessing step which accounts for corner cases with Motoko's relatively new multi-line text literals. 