### PR TITLE
Use Prettier 2 for standalone CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.9.1",
+    "version": "0.9.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.9.1",
+            "version": "0.9.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"
@@ -1547,12 +1547,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -2200,9 +2200,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -5512,9 +5512,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.1.15",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-            "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
             "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
@@ -7311,12 +7311,12 @@
             }
         },
         "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "requires": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             }
         },
         "browserslist": {
@@ -7781,9 +7781,9 @@
             }
         },
         "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
@@ -10198,9 +10198,9 @@
             "dev": true
         },
         "tar": {
-            "version": "6.1.15",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-            "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
             "dev": true,
             "requires": {
                 "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "build": "run-s build:wasm build:ts",
         "test": "npm run build:wasm:nodejs && npm run test:quick",
         "test:quick": "node --experimental-vm-modules node_modules/jest/bin/jest",
-        "package": "rimraf ./pkg && run-s build test && pkg -t node14-linux,node14-win,node14-macos bin/mo-fmt.js -o pkg/mo-fmt",
+        "package": "cd packages/mo-fmt && npm run package",
         "prepublishOnly": "run-s build test:quick"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mo-fmt",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.9.2",
+            "version": "0.9.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
-                "prettier": "^3.0",
+                "prettier": "2",
                 "prettier-plugin-motoko": "^0.9.2"
             },
             "bin": {
@@ -1594,11 +1594,11 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -2234,9 +2234,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -4649,14 +4649,14 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-            "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "bin": {
-                "prettier": "bin/prettier.cjs"
+                "prettier": "bin-prettier.js"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=10.13.0"
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -7041,11 +7041,11 @@
             }
         },
         "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "requires": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             }
         },
         "browserslist": {
@@ -7510,9 +7510,9 @@
             }
         },
         "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -9278,9 +9278,9 @@
             }
         },
         "prettier": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-            "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g=="
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
             "version": "0.9.2",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -12,7 +12,7 @@
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "2",
-                "prettier-plugin-motoko": "^0.9.2"
+                "prettier-plugin-motoko": "^0.9.3"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4663,9 +4663,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.9.2.tgz",
-            "integrity": "sha512-+FIPZkfIzOn0021zFQfmxnE32bl9KUJelEigW5akh32JAEZEidkaFpdEbaqLnWCQotq/Y1JO3l/I6u3uDLfiBA==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.9.3.tgz",
+            "integrity": "sha512-/lNNZLVPcx6Vu2PUVAWSuFAzrQPbmntX1YJvqV9KNuVvm2PmfA1TATXUb6Ukx/dmGa3gJ5UsXlYIR8+DoM6KLw==",
             "dependencies": {
                 "out-of-character": "^1.2.1"
             },
@@ -9283,9 +9283,9 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.9.2.tgz",
-            "integrity": "sha512-+FIPZkfIzOn0021zFQfmxnE32bl9KUJelEigW5akh32JAEZEidkaFpdEbaqLnWCQotq/Y1JO3l/I6u3uDLfiBA==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.9.3.tgz",
+            "integrity": "sha512-/lNNZLVPcx6Vu2PUVAWSuFAzrQPbmntX1YJvqV9KNuVvm2PmfA1TATXUb6Ukx/dmGa3gJ5UsXlYIR8+DoM6KLw==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
-        "prettier": "^3.0",
+        "prettier": "2",
         "prettier-plugin-motoko": "^0.9.2"
     },
     "devDependencies": {

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -22,7 +22,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "2",
-        "prettier-plugin-motoko": "^0.9.2"
+        "prettier-plugin-motoko": "^0.9.3"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",


### PR DESCRIPTION
Fixes an issue with `mo-fmt` related to using Prettier 3 with [`pkg`](https://www.npmjs.com/package/pkg). This is solved by downgrading to Prettier 2 in the standalone CLI.