### PR TITLE
Fix unary operator after keyword

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "2",
-                "prettier-plugin-motoko": "^0.10.0"
+                "prettier-plugin-motoko": "^0.10.1"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4827,9 +4827,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.0.tgz",
-            "integrity": "sha512-jays/MhazH0rd9RB7oDymLTWTdSH9lO+Q1BXoGE7cTsJUj73O3OcGZLFMXCIAmekSC91Lt8GyyCWtfXhndp9xA==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.1.tgz",
+            "integrity": "sha512-8Hi6weDwsprmJ8qRV0gk1vy+QVsLQD0SweGvaHCskHYGsEPs317/w5sALuS348Zptnb8YkAKzo4ufM+cYIAM8g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"
@@ -9571,9 +9571,9 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.0.tgz",
-            "integrity": "sha512-jays/MhazH0rd9RB7oDymLTWTdSH9lO+Q1BXoGE7cTsJUj73O3OcGZLFMXCIAmekSC91Lt8GyyCWtfXhndp9xA==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.1.tgz",
+            "integrity": "sha512-8Hi6weDwsprmJ8qRV0gk1vy+QVsLQD0SweGvaHCskHYGsEPs317/w5sALuS348Zptnb8YkAKzo4ufM+cYIAM8g==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -22,7 +22,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "2",
-        "prettier-plugin-motoko": "^0.10.0"
+        "prettier-plugin-motoko": "^0.10.1"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -98,8 +98,16 @@ const tokenEndsWith = (end: string) =>
 const tokenTypes = (types: Token['token_type'][]) =>
     token((token) => types.includes(token.token_type));
 
-const any = (conditions: ((tt: TokenTree) => boolean)[]) => (tt: TokenTree) =>
-    conditions.some((condition) => condition(tt));
+const and =
+    (...conditions: ((tt: TokenTree) => boolean)[]) =>
+    (tt: TokenTree) =>
+        conditions.every((condition) => condition(tt));
+const or =
+    (...conditions: ((tt: TokenTree) => boolean)[]) =>
+    (tt: TokenTree) =>
+        conditions.some((condition) => condition(tt));
+const not = (condition: (tt: TokenTree) => boolean) => (tt: TokenTree) =>
+    !condition(tt);
 
 // match both "block comments" and "comment groups" (lexer implementation detail)
 const blockComment = (tt: TokenTree) =>
@@ -136,8 +144,11 @@ const spaceConfig: SpaceConfig = {
         // unary operators
         [
             {
-                left: tokenTypes(['Close', 'Ident', 'Literal']),
-                main: any([tokenEquals('+'), tokenEquals('-')]),
+                left: and(
+                    tokenTypes(['Close', 'Ident', 'Literal']),
+                    not(keyword),
+                ),
+                main: or(tokenEquals('+'), tokenEquals('-')),
             },
             '_',
             'space',

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -569,6 +569,7 @@ public type T = {
         await expectFormatted('1 + 1\n');
         await expectFormatted('x + 1\n');
         await expectFormatted('x - +1\n');
+        await expectFormatted('return +1\n');
         expect(await format('1+1')).toEqual('1 + 1\n');
         expect(await format('1+1.0')).toEqual('1 + 1.0\n');
         expect(await format('x+1')).toEqual('x + 1\n');
@@ -585,6 +586,7 @@ public type T = {
         await expectFormatted('x + -1\n');
         await expectFormatted('x; -1\n');
         await expectFormatted('x(-1)\n');
+        await expectFormatted('return -1\n');
         expect(await format('1-1')).toEqual('1 - 1\n');
         expect(await format('1.0-1.0')).toEqual('1.0 - 1.0\n');
         expect(await format('x-1')).toEqual('x - 1\n');


### PR DESCRIPTION
Fixes a regression where a unary operator following a keyword such as `return -1` was formatted as `return - 1`.
