### PR TITLE
Fix formatting optional variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.10.1",
+            "version": "0.10.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.10.1",
+            "version": "0.10.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "2",
-                "prettier-plugin-motoko": "^0.10.1"
+                "prettier-plugin-motoko": "^0.10.2"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4827,9 +4827,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.1.tgz",
-            "integrity": "sha512-8Hi6weDwsprmJ8qRV0gk1vy+QVsLQD0SweGvaHCskHYGsEPs317/w5sALuS348Zptnb8YkAKzo4ufM+cYIAM8g==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.2.tgz",
+            "integrity": "sha512-/94ns1Js51+6dYQF66kLBJvps7a147Pl7UHamxec5HovhV3eU/s0gkjLooxb9zYpjkd6e8Q2Ol5ugdrTiaz24A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"
@@ -9571,9 +9571,9 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.1.tgz",
-            "integrity": "sha512-8Hi6weDwsprmJ8qRV0gk1vy+QVsLQD0SweGvaHCskHYGsEPs317/w5sALuS348Zptnb8YkAKzo4ufM+cYIAM8g==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.2.tgz",
+            "integrity": "sha512-/94ns1Js51+6dYQF66kLBJvps7a147Pl7UHamxec5HovhV3eU/s0gkjLooxb9zYpjkd6e8Q2Ol5ugdrTiaz24A==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -22,7 +22,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "2",
-        "prettier-plugin-motoko": "^0.10.1"
+        "prettier-plugin-motoko": "^0.10.2"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -147,6 +147,12 @@ const spaceConfig: SpaceConfig = {
         [tokenEquals('^'), '_', 'keep'],
         // [tokenEquals('#'), 'Ident', 'keep'],
 
+        // prefix/postfix operators
+        [{ left: tokenEquals('do'), main: tokenEquals('?') }, '_', 'space'],
+        // [tokenEquals('?'), 'Curly', 'keep'],
+        [tokenEquals('?'), '_', 'nil'],
+        ['_', tokenEquals('!'), 'nil'],
+
         // tags and concatenation
         ['_', tokenEquals('#'), 'keep-space'],
         [tokenEquals('#'), 'Ident', 'keep'],
@@ -173,12 +179,6 @@ const spaceConfig: SpaceConfig = {
         // ['_', 'Dot', 'softwrap'],
         ['Dot', '_', 'nil'],
         ['Assign', '_', 'space'],
-
-        // prefix/postfix operators
-        [{ left: tokenEquals('do'), main: tokenEquals('?') }, '_', 'space'],
-        // [tokenEquals('?'), 'Curly', 'keep'],
-        [tokenEquals('?'), '_', 'nil'],
-        ['_', tokenEquals('!'), 'nil'],
 
         // space between identifier and group
         [tokenEquals('func'), 'Paren', 'nil'],

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -593,4 +593,9 @@ public type T = {
         expect(await format('1 -1')).toEqual('1 - 1\n');
         expect(await format('x -1')).toEqual('x - 1\n');
     });
+
+    test('optional variants', async () => {
+        await expectFormatted('?#abc\n');
+        expect(await format('? #abc')).toEqual('?#abc\n');
+    });
 });


### PR DESCRIPTION
Adjusts the formatting rules so that `?#variant` remains formatted and `? #variant` is replaced with `?#variant`. 
