### PR TITLE
Fix corner case with exponential float literal

### DIFF
--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -516,6 +516,12 @@ public type T = {
         expect(await format('@abc')).toStrictEqual('@abc\n');
     });
 
+    test('scientific notation literals', async () => {
+        await expectFormatted('let f = 1e2;\n');
+        await expectFormatted('let f = -1e-2;\n');
+        await expectFormatted('let f = 1.7976931348623157e+308;\n');
+    });
+
     test('multi-line text', async () => {
         await expectFormatted('"A\nB"\n');
         await expectFormatted('"  A\n  B"\n');

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 wasm-bindgen = { version = "=0.2.82" }
 serde-wasm-bindgen = "=0.4.3"
-motoko = "0.0.29"
+motoko = "0.0.30"
 
 console_error_panic_hook = { version = "0.1.6", optional = true }
 


### PR DESCRIPTION
Fixes formatting exponential notation with a positive sign, e.g. `1e+1`.