### PR TITLE
Update rust dependencies

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ryan Vandersmith <ryan.vandersmith@dfinity.org>"]
 edition = "2018"
 
@@ -11,16 +11,16 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-serde = { version = "1.0.143", features = ["derive"] }
-serde_json = "1.0.83"
-wasm-bindgen = { version = "=0.2.82" }
-serde-wasm-bindgen = "=0.4.3"
-motoko = "0.0.29"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.135"
+wasm-bindgen = { version = "=0.2.99" }
+serde-wasm-bindgen = "=0.6.5"
+motoko = "0.0.30"
 
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.13"
+wasm-bindgen-test = "0.3.49"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.


### PR DESCRIPTION
I also looked into issue #142 today (problem with formatting some unicode/emojis chars) and found a similar issue related to a specific version of wasm-pack: https://github.com/rustwasm/wasm-pack/issues/1389#issuecomment-2102887487

Updating the dependencies seems to resolve the issue. The tests from PR #151 are passing and the snippet I had issues with also doesn't crash any more.