### PR TITLE
Add exception to delimiter logic for parenthesized `with` syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.10.3",
+            "version": "0.10.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.10.3",
+            "version": "0.10.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "2",
-                "prettier-plugin-motoko": "^0.10.3"
+                "prettier-plugin-motoko": "^0.10.4"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4827,9 +4827,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.3.tgz",
-            "integrity": "sha512-U5ao1uha9NqmGAXSrukclHk/hY5l5oMHAXvbvLkiv+s4fFKr8dud1wHX67J1+UZT6zAt3soD3MuePUmszQMCBg==",
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.4.tgz",
+            "integrity": "sha512-SPx2a4w6gIP1gXFjyIHs+SmscOHlEi88pAb+9XVKOlCeOy1rTXbucWJ/L420atNkf5jRpYqPDGFP1Zx2mv99Fg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"
@@ -9571,9 +9571,9 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.3.tgz",
-            "integrity": "sha512-U5ao1uha9NqmGAXSrukclHk/hY5l5oMHAXvbvLkiv+s4fFKr8dud1wHX67J1+UZT6zAt3soD3MuePUmszQMCBg==",
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.4.tgz",
+            "integrity": "sha512-SPx2a4w6gIP1gXFjyIHs+SmscOHlEi88pAb+9XVKOlCeOy1rTXbucWJ/L420atNkf5jRpYqPDGFP1Zx2mv99Fg==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -22,7 +22,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "2",
-        "prettier-plugin-motoko": "^0.10.3"
+        "prettier-plugin-motoko": "^0.10.4"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -617,6 +617,8 @@ public type T = {
     });
 
     test('parenthesized `with` expression', async () => {
+        await expectFormatted('(m with a = 1) actor {}\n');
+        await expectFormatted('(m with a = 1; b = 2) actor {}\n');
         await expectFormatted('(m with a = 1) actor {};\n');
         await expectFormatted('(m with a = 1; b = 2) actor {};\n');
         expect(await format('(m with a = 1; b = 2;) actor {};')).toEqual('(m with a = 1; b = 2) actor {};\n');

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -615,4 +615,11 @@ public type T = {
         await expectFormatted('?#abc\n');
         expect(await format('? #abc')).toEqual('?#abc\n');
     });
+
+    test('parenthesized `with` expression', async () => {
+        await expectFormatted('(x with a = 1);\n');
+        await expectFormatted('(x with a = 1; b = 2);\n');
+        expect(await format('(x with a = 1; b = 2;);')).toEqual('(x with a = 1; b = 2);\n');
+        expect(await format('(x with a = 1, b = 2,);')).toEqual('(x with a = 1; b = 2);\n');
+    });
 });

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -617,6 +617,8 @@ public type T = {
     });
 
     test('parenthesized `with` expression', async () => {
+        await expectFormatted('(with a = 1) actor {}\n');
+        await expectFormatted('(with a = 1; b = 2) actor {}\n');
         await expectFormatted('(m with a = 1) actor {}\n');
         await expectFormatted('(m with a = 1; b = 2) actor {}\n');
         await expectFormatted('(m with a = 1) actor {};\n');

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -617,9 +617,9 @@ public type T = {
     });
 
     test('parenthesized `with` expression', async () => {
-        await expectFormatted('(x with a = 1);\n');
-        await expectFormatted('(x with a = 1; b = 2);\n');
-        expect(await format('(x with a = 1; b = 2;);')).toEqual('(x with a = 1; b = 2);\n');
-        expect(await format('(x with a = 1, b = 2,);')).toEqual('(x with a = 1; b = 2);\n');
+        await expectFormatted('(m with a = 1) actor {};\n');
+        await expectFormatted('(m with a = 1; b = 2) actor {};\n');
+        expect(await format('(m with a = 1; b = 2;) actor {};')).toEqual('(m with a = 1; b = 2) actor {};\n');
+        expect(await format('(m with a = 1, b = 2,) actor {};')).toEqual('(m with a = 1; b = 2) actor {};\n');
     });
 });


### PR DESCRIPTION
Accounts for new syntax in https://github.com/dfinity/motoko/pull/4812.