### PR TITLE
Allow optional newline after `(with)` expression prefixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.10.4",
+            "version": "0.10.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.10.4",
+            "version": "0.10.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "2",
-                "prettier-plugin-motoko": "^0.10.4"
+                "prettier-plugin-motoko": "^0.10.5"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4827,9 +4827,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.4.tgz",
-            "integrity": "sha512-SPx2a4w6gIP1gXFjyIHs+SmscOHlEi88pAb+9XVKOlCeOy1rTXbucWJ/L420atNkf5jRpYqPDGFP1Zx2mv99Fg==",
+            "version": "0.10.5",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.5.tgz",
+            "integrity": "sha512-rEP6IUTqZ90ZUGGIZIS7GTF0SOIinAleQq1WP7Tdfvdo35WnLHxv0SOiIH+M8ef3RMKdHfU4uGiH3pbQ73nSpg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"
@@ -9571,9 +9571,9 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.4.tgz",
-            "integrity": "sha512-SPx2a4w6gIP1gXFjyIHs+SmscOHlEi88pAb+9XVKOlCeOy1rTXbucWJ/L420atNkf5jRpYqPDGFP1Zx2mv99Fg==",
+            "version": "0.10.5",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.5.tgz",
+            "integrity": "sha512-rEP6IUTqZ90ZUGGIZIS7GTF0SOIinAleQq1WP7Tdfvdo35WnLHxv0SOiIH+M8ef3RMKdHfU4uGiH3pbQ73nSpg==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "An easy-to-use Motoko formatter command.",
     "main": "src/cli.js",
     "bin": {
@@ -22,7 +22,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "2",
-        "prettier-plugin-motoko": "^0.10.4"
+        "prettier-plugin-motoko": "^0.10.5"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -98,6 +98,13 @@ const tokenEndsWith = (end: string) =>
 const tokenTypes = (types: Token['token_type'][]) =>
     token((token) => types.includes(token.token_type));
 
+const groupContains =
+    (groupType: GroupType, predicate: (tt: TokenTree) => boolean) =>
+    (tt: TokenTree) =>
+        tt.token_tree_type === 'Group' &&
+        tt.data[1] === groupType &&
+        tt.data[0].some(predicate);
+
 const and =
     (...conditions: ((tt: TokenTree) => boolean)[]) =>
     (tt: TokenTree) =>
@@ -173,18 +180,7 @@ const spaceConfig: SpaceConfig = {
         [tokenEquals('with'), '_', 'keep-space'],
 
         // '(with)' expression prefixes
-        [
-            (tt: TokenTree) =>
-                tt.token_tree_type === 'Group' &&
-                tt.data[1] === 'Paren' &&
-                tt.data[0].some(
-                    (token) =>
-                        token.token_tree_type === 'Token' &&
-                        token.data[0].data === 'with',
-                ),
-            '_',
-            'keep-space',
-        ],
+        [groupContains('Paren', tokenEquals('with')), '_', 'keep-space'],
 
         // logical and pipe operators
         [

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -172,6 +172,20 @@ const spaceConfig: SpaceConfig = {
         // 'with' keyword
         [tokenEquals('with'), '_', 'keep-space'],
 
+        // '(with)' expression prefixes
+        [
+            (tt: TokenTree) =>
+                tt.token_tree_type === 'Group' &&
+                tt.data[1] === 'Paren' &&
+                tt.data[0].some(
+                    (token) =>
+                        token.token_tree_type === 'Token' &&
+                        token.data[0].data === 'with',
+                ),
+            '_',
+            'keep-space',
+        ],
+
         // logical and pipe operators
         [
             { main: tokenEquals('and'), groups: ['Paren', 'Square'] },

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -495,9 +495,9 @@ public type T = {
         expect(await format('import  Prim  "mo:⛔";')).toStrictEqual(
             'import Prim "mo:⛔";\n',
         );
-        expect(await format('import  Prim  "mo:⛔";'.repeat(100))).toStrictEqual(
-            'import Prim "mo:⛔";\n'.repeat(100),
-        );
+        expect(
+            await format('import  Prim  "mo:⛔";'.repeat(100)),
+        ).toStrictEqual('import Prim "mo:⛔";\n'.repeat(100));
     });
 
     test('invisible unicode characters', async () => {
@@ -616,14 +616,32 @@ public type T = {
         expect(await format('? #abc')).toEqual('?#abc\n');
     });
 
-    test('parenthesized `with` expression', async () => {
+    test('parenthesized `with` expression prefixes', async () => {
         await expectFormatted('(with a = 1) actor {}\n');
         await expectFormatted('(with a = 1; b = 2) actor {}\n');
         await expectFormatted('(m with a = 1) actor {}\n');
         await expectFormatted('(m with a = 1; b = 2) actor {}\n');
         await expectFormatted('(m with a = 1) actor {};\n');
         await expectFormatted('(m with a = 1; b = 2) actor {};\n');
-        expect(await format('(m with a = 1; b = 2;) actor {};')).toEqual('(m with a = 1; b = 2) actor {};\n');
-        expect(await format('(m with a = 1, b = 2,) actor {};')).toEqual('(m with a = 1; b = 2) actor {};\n');
+        expect(await format('(m with a = 1; b = 2;) actor {};')).toEqual(
+            '(m with a = 1; b = 2) actor {};\n',
+        );
+        expect(await format('(m with a = 1, b = 2,) actor {};')).toEqual(
+            '(m with a = 1; b = 2) actor {};\n',
+        );
+
+        await expectFormatted('(with a = 1)\nactor {};\n');
+        await expectFormatted('(with a = 1; b = 2)\nactor {};\n');
+        await expectFormatted('(m with a = 1)\nactor {};\n');
+        await expectFormatted('(m with a = 1; b = 2)\nactor {};\n');
+        await expectFormatted('(m with a = 1) actor {};\n');
+        await expectFormatted('(m with a = 1; b = 2)\nactor {};\n');
+
+        await expectFormatted(
+            '(\n  m with\n  a = 1;\n  b = 2;\n) actor {};\n',
+        );
+        await expectFormatted(
+            '(\n  m with\n  a = 1;\n  b = 2;\n)\nactor {};\n',
+        );
     });
 });

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -495,9 +495,9 @@ public type T = {
         expect(await format('import  Prim  "mo:⛔";')).toStrictEqual(
             'import Prim "mo:⛔";\n',
         );
-        expect(
-            await format('import  Prim  "mo:⛔";'.repeat(100)),
-        ).toStrictEqual('import Prim "mo:⛔";\n'.repeat(100));
+        expect(await format('import  Prim  "mo:⛔";'.repeat(100))).toStrictEqual(
+            'import Prim "mo:⛔";\n'.repeat(100),
+        );
     });
 
     test('invisible unicode characters', async () => {
@@ -638,7 +638,7 @@ public type T = {
         await expectFormatted('(m with a = 1; b = 2)\nactor {};\n');
 
         await expectFormatted(
-            '(\n  m with\n  a = 1;\n  b = 2;\n) actor {};\n',
+            '(\n  m with\n  a = 1;\n  b = 2;\n)\nactor {};\n',
         );
         await expectFormatted(
             '(\n  m with\n  a = 1;\n  b = 2;\n)\nactor {};\n',


### PR DESCRIPTION
Adjusts the whitespace logic to preserve newlines after parenthesized `(with)` expression prefixes.