### PR TITLE
Add option to remove empty lines around code blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.12.0",
+            "version": "0.12.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.11.3",
+    "version": "0.12.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.11.3",
+            "version": "0.12.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "2",
-                "prettier-plugin-motoko": "^0.11.3"
+                "prettier-plugin-motoko": "^0.12.0"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4683,9 +4683,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.11.3",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.11.3.tgz",
-            "integrity": "sha512-RsUqim0ZriHTxAYKHgyDBA2xu6Tp77kJFr1CfJn5vuC8OR3roCt3+4GYGVfnDCX5IqtZs8vtNp4ZUFT059xp7Q==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.12.0.tgz",
+            "integrity": "sha512-DxwQOGXyRLgz3LczDPNQ4s94L5QCcO77FHxraboREqtDNsOYs5PHbboMCru2cOxUUjSyTAeIKBOlSp/Qo9LRyQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"
@@ -9303,9 +9303,9 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.11.3",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.11.3.tgz",
-            "integrity": "sha512-RsUqim0ZriHTxAYKHgyDBA2xu6Tp77kJFr1CfJn5vuC8OR3roCt3+4GYGVfnDCX5IqtZs8vtNp4ZUFT059xp7Q==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.12.0.tgz",
+            "integrity": "sha512-DxwQOGXyRLgz3LczDPNQ4s94L5QCcO77FHxraboREqtDNsOYs5PHbboMCru2cOxUUjSyTAeIKBOlSp/Qo9LRyQ==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.12.0",
+            "version": "0.12.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "2",
-                "prettier-plugin-motoko": "^0.12.0"
+                "prettier-plugin-motoko": "^0.12.1"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4683,9 +4683,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.12.0.tgz",
-            "integrity": "sha512-DxwQOGXyRLgz3LczDPNQ4s94L5QCcO77FHxraboREqtDNsOYs5PHbboMCru2cOxUUjSyTAeIKBOlSp/Qo9LRyQ==",
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.12.1.tgz",
+            "integrity": "sha512-CayRs+sSKgeE+YBbbyEvfJTtUDPiR0wzkYmGW7gFF/5pS2Y2TtaQKeKkjTyRdm3hORMOp5NwxviWRuxbMNP+Tg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "out-of-character": "^1.2.1"
@@ -9303,9 +9303,9 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.12.0.tgz",
-            "integrity": "sha512-DxwQOGXyRLgz3LczDPNQ4s94L5QCcO77FHxraboREqtDNsOYs5PHbboMCru2cOxUUjSyTAeIKBOlSp/Qo9LRyQ==",
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.12.1.tgz",
+            "integrity": "sha512-CayRs+sSKgeE+YBbbyEvfJTtUDPiR0wzkYmGW7gFF/5pS2Y2TtaQKeKkjTyRdm3hORMOp5NwxviWRuxbMNP+Tg==",
             "requires": {
                 "out-of-character": "^1.2.1"
             }

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "A standalone Motoko formatter CLI.",
     "main": "src/cli.js",
     "bin": {
@@ -22,7 +22,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "2",
-        "prettier-plugin-motoko": "^0.12.0"
+        "prettier-plugin-motoko": "^0.12.1"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,8 +1,12 @@
 import { SupportOption } from 'prettier';
 
 const options: Record<string, SupportOption> = {
-    // replaceComma: {
-    // },
+    motokoRemoveLinesAroundCodeBlocks: {
+        category: 'motoko',
+        type: 'boolean',
+        default: false,
+        description: 'Remove extra lines around code blocks',
+    },
 };
 
 export default options;

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -203,7 +203,17 @@ function printTokenTree(
             if (right) {
                 rightMap.set(tt, right);
             }
-            return !shouldSkipTokenTree(tt);
+            return (
+                !shouldSkipTokenTree(tt) &&
+                !(
+                    // Remove empty lines at start/end of code block
+                    (
+                        options.motokoRemoveLinesAroundCodeBlocks &&
+                        getToken(tt)?.token_type === 'MultiLine' &&
+                        (i === 0 || i === originalTrees.length - 1)
+                    )
+                )
+            );
         });
 
         // nested groups such as `((a, b, ...))`
@@ -234,7 +244,6 @@ function printTokenTree(
             let hasWith = false;
             let hasAnd = false;
             let hasAssign = false;
-            let hasColon = false;
             let hasDelim = false;
             trees.forEach((tree) => {
                 let token = getToken(tree);
@@ -251,8 +260,6 @@ function printTokenTree(
                     token.data === '='
                 ) {
                     hasAssign = true;
-                } else if (token.token_type === 'Colon') {
-                    hasColon = true;
                 } else if (token.token_type === 'Delim') {
                     hasDelim = true;
                 }
@@ -361,7 +368,7 @@ function printTokenTree(
                             : printTokenTree(a, path, options, print, args),
                     );
                 }
-                if (i < trees.length - 1 && !isIgnoreComment) {
+                if (!isIgnoreComment && i !== trees.length - 1) {
                     resultArray.push(
                         printBetween(
                             groupType,

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -658,11 +658,54 @@ public type T = {
 
     test('double newline after import section', async () => {
         expectFormatted(await format('import A "A";\n\nactor {};\n'));
-        expectFormatted(await format('import A "A";\nimport B "B";\n\nactor {};\n'));
-        expectFormatted(await format('import A "A";\n// import B "B";\n\nactor {};\n'));
-        expectFormatted(await format('import A "A";\n// import B "B";\nimport { C } "C";\n\nactor {};\n'));
-        expect(await format('import A "A"; actor {}')).toEqual('import A "A";\n\nactor {};\n');
-        expect(await format('import A "A";\n// import B "B";\nimport C "C";\nactor {};')).toEqual('import A "A";\n// import B "B";\nimport C "C";\n\nactor {};\n');
-        expect(await format('import A "A";\nimport {B} "B";\n// import C "C";\nactor A {\nabc\n};')).toEqual('import A "A";\nimport { B } "B";\n// import C "C";\n\nactor A {\n  abc;\n};\n');
+        expectFormatted(
+            await format('import A "A";\nimport B "B";\n\nactor {};\n'),
+        );
+        expectFormatted(
+            await format('import A "A";\n// import B "B";\n\nactor {};\n'),
+        );
+        expectFormatted(
+            await format(
+                'import A "A";\n// import B "B";\nimport { C } "C";\n\nactor {};\n',
+            ),
+        );
+        expect(await format('import A "A"; actor {}')).toEqual(
+            'import A "A";\n\nactor {};\n',
+        );
+        expect(
+            await format(
+                'import A "A";\n// import B "B";\nimport C "C";\nactor {};',
+            ),
+        ).toEqual(
+            'import A "A";\n// import B "B";\nimport C "C";\n\nactor {};\n',
+        );
+        expect(
+            await format(
+                'import A "A";\nimport {B} "B";\n// import C "C";\nactor A {\nabc\n};',
+            ),
+        ).toEqual(
+            'import A "A";\nimport { B } "B";\n// import C "C";\n\nactor A {\n  abc;\n};\n',
+        );
+    });
+
+    test('lines before/after group', async () => {
+        await expectFormatted('[\n\n  1,\n  2,\n\n];\n');
+        await expectFormatted('{\n\n  abc;\n\n};\n');
+
+        const options: prettier.Options = {
+            motokoRemoveLinesAroundCodeBlocks: true,
+        };
+        expect(await format('[\n\n1,\n2,\n\n]\n', options)).toEqual(
+            '[\n  1,\n  2,\n];\n',
+        );
+        expect(await format('{\n\nabc\n\n}\n', options)).toEqual(
+            '{\n  abc;\n};\n',
+        );
+        expect(await format('{\n\n1;\n2;\n\n3;\n\n}\n', options)).toEqual(
+            '{\n  1;\n  2;\n\n  3;\n};\n',
+        );
+        expect(await format('actor {\n\nfunc f() {\n\nlet a = 0;\n\n}\n\n}\n', options)).toEqual(
+            'actor {\n  func f() {\n    let a = 0;\n  };\n};\n',
+        );
     });
 });


### PR DESCRIPTION
Example `.prettierrc` file:

```json
{
  "plugins": ["prettier-plugin-motoko"],
  "motokoRemoveLinesAroundCodeBlocks": true
}
```