### PR TITLE
Adjust formatting rules for null coalesce operator

### DIFF
--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -170,7 +170,11 @@ const spaceConfig: SpaceConfig = {
         // prefix/postfix operators
         [{ left: tokenEquals('do'), main: tokenEquals('?') }, '_', 'space'],
         // [tokenEquals('?'), 'Curly', 'keep'],
-        [tokenEquals('?'), '_', 'nil'],
+
+        // optional syntax and null coalesce operator
+        ['_', tokenEquals('?'), 'keep'],
+        [tokenEquals('?'), '_', 'keep'],
+
         ['_', tokenEquals('!'), 'nil'],
 
         // tags and concatenation

--- a/src/printers/motoko-tt-ast/spaceConfig.ts
+++ b/src/printers/motoko-tt-ast/spaceConfig.ts
@@ -168,12 +168,15 @@ const spaceConfig: SpaceConfig = {
         // [tokenEquals('#'), 'Ident', 'keep'],
 
         // prefix/postfix operators
+        [tokenEquals('do'), tokenEquals('?'), 'space'],
         [{ left: tokenEquals('do'), main: tokenEquals('?') }, '_', 'space'],
         // [tokenEquals('?'), 'Curly', 'keep'],
 
         // optional syntax and null coalesce operator
-        ['_', tokenEquals('?'), 'keep'],
-        [tokenEquals('?'), '_', 'keep'],
+        [{ left: tokenEquals('?'), main: tokenEquals('?') }, '_', 'keep'],
+        ['_', { main: tokenEquals('?'), right: tokenEquals('?') }, 'keep'],
+        ['_', tokenEquals('?'), 'nil'],
+        [tokenEquals('?'), '_', 'nil'],
 
         ['_', tokenEquals('!'), 'nil'],
 

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -111,7 +111,8 @@ describe('Motoko formatter', () => {
 
     test('do ? / optional', async () => {
         expect(await format('?{}')).toStrictEqual('?{}\n');
-        // expect(await format('do?{}')).toStrictEqual('do ? {}\n');
+        await expectFormatted('do ? {}\n');
+        expect(await format('do?{}')).toStrictEqual('do ? {}\n');
     });
 
     test('anonymous functions', async () => {
@@ -572,16 +573,16 @@ public type T = {
         await expectFormatted('a ?? b ?? c\n');
         await expectFormatted('a\n?? b;\n');
         await expectFormatted('(\n  a\n  ?? b\n);\n');
-        
+
         await expectFormatted('?a\n');
         await expectFormatted('??a\n');
-        // expect(await format('? ?a')).toStrictEqual('??a\n');
+        expect(await format('? ?a')).toStrictEqual('??a\n');
         await expectFormatted('a ?? ?b\n');
         await expectFormatted('?a ?? b\n');
         await expectFormatted('?a ?? ?b\n');
         await expectFormatted('??a ?? b\n');
         await expectFormatted('a ?? ??b\n');
-        
+
         await expectFormatted('(a) ?? b\n');
         await expectFormatted('a ?? (b)\n');
         await expectFormatted('(a) ?? (b)\n');
@@ -640,7 +641,7 @@ public type T = {
 
     test('optional variants', async () => {
         await expectFormatted('?#abc\n');
-        // expect(await format('? #abc')).toEqual('?#abc\n');
+        expect(await format('? #abc')).toEqual('?#abc\n');
     });
 
     test('parenthesized `with` expression prefixes', async () => {

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -111,7 +111,7 @@ describe('Motoko formatter', () => {
 
     test('do ? / optional', async () => {
         expect(await format('?{}')).toStrictEqual('?{}\n');
-        expect(await format('do?{}')).toStrictEqual('do ? {}\n');
+        // expect(await format('do?{}')).toStrictEqual('do ? {}\n');
     });
 
     test('anonymous functions', async () => {
@@ -564,6 +564,33 @@ public type T = {
         expect(await format('(A\n|> B)')).toStrictEqual('(\n  A\n  |> B\n);\n');
     });
 
+    test('null coalesce operator', async () => {
+        // expect(await format('a??b')).toStrictEqual('a ?? b\n');
+        await expectFormatted('a ?? b\n');
+        expect(await format('a  ??  b')).toStrictEqual('a ?? b\n');
+        // expect(await format('(a??b)')).toStrictEqual('(a ?? b)\n');
+        await expectFormatted('a ?? b ?? c\n');
+        await expectFormatted('a\n?? b;\n');
+        await expectFormatted('(\n  a\n  ?? b\n);\n');
+        
+        await expectFormatted('?a\n');
+        await expectFormatted('??a\n');
+        // expect(await format('? ?a')).toStrictEqual('??a\n');
+        await expectFormatted('a ?? ?b\n');
+        await expectFormatted('?a ?? b\n');
+        await expectFormatted('?a ?? ?b\n');
+        await expectFormatted('??a ?? b\n');
+        await expectFormatted('a ?? ??b\n');
+        
+        await expectFormatted('(a) ?? b\n');
+        await expectFormatted('a ?? (b)\n');
+        await expectFormatted('(a) ?? (b)\n');
+        await expectFormatted('(a ?? b) ?? c\n');
+        await expectFormatted('a ?? (b ?? c)\n');
+        await expectFormatted('(?a) ?? b\n');
+        await expectFormatted('a ?? (?b)\n');
+    });
+
     test('function in type bindings', async () => {
         await expectFormatted('f<() -> (), Nat>();\n');
         await expectFormatted('f<() -> (), () -> ())>();\n');
@@ -613,7 +640,7 @@ public type T = {
 
     test('optional variants', async () => {
         await expectFormatted('?#abc\n');
-        expect(await format('? #abc')).toEqual('?#abc\n');
+        // expect(await format('? #abc')).toEqual('?#abc\n');
     });
 
     test('parenthesized `with` expression prefixes', async () => {


### PR DESCRIPTION
Adds spacing rules for the new `??` null coalesce operator merged in caffeinelabs/motoko#5722.

### Before / After

```motoko
// Input
a  ??  b
do?{}

// Output
a ?? b
do ? {}
```

User-typed spacing around `??` is preserved (no spaces inserted between adjacent `?` tokens, so `??a`, `?a ?? b`, `a ?? ?b`, etc. all round-trip cleanly). `do ?` keeps its space.

### Notes

- No lexer/parser changes — purely `spaceConfig` rules + tests.
- Two cases intentionally left as TODO: `a??b` and `(a??b)` aren't auto-spaced. Motoko's lexer requires whitespace after `??` to emit `NULLCOALESCE`, so the formatter can't safely insert spaces without semantic info.