### PR TITLE
Add optional "organize imports" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Automatically organize and sort import statements. When enabled, imports are:
 - Sorted alphabetically within each group
 - Combined when importing from the same path
 - Separated by blank lines between groups
+- Comments within the import section are preserved and moved below the organized imports
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,47 @@ Add the following line to your config file:
 }
 ```
 
+### Motoko-specific options
+
+#### `motokoOrganizeImports` (default: `false`)
+
+Automatically organize and sort import statements. When enabled, imports are:
+- Grouped by prefix (`ic:`, `canister:`, `mo:`, and relative paths)
+- Sorted alphabetically within each group
+- Combined when importing from the same path
+- Separated by blank lines between groups
+
+Example:
+
+```motoko
+// Before formatting
+import Text "mo:base/Text";
+import Utils "./utils";
+import Core "canister:core";
+import Array "mo:base/Array";
+
+// After formatting with motokoOrganizeImports: true
+import Core "canister:core";
+
+import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+import Utils "./utils";
+```
+
+To enable this option, add it to your `.prettierrc`:
+
+```json
+{
+    "plugins": ["prettier-plugin-motoko"],
+    "motokoOrganizeImports": true
+}
+```
+
+#### `motokoRemoveLinesAroundCodeBlocks` (default: `false`)
+
+Remove extra blank lines at the beginning and end of code blocks.
+
 ## Multiple languages
 
 Prettier will apply the same configuration to Motoko, JavaScript, CSS, HTML, and any other supported languages. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.12.4",
+    "version": "0.13.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-motoko",
-            "version": "0.12.4",
+            "version": "0.13.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "^28.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-motoko",
-    "version": "0.12.5",
+    "version": "0.13.0",
     "description": "A code formatter for the Motoko smart contract language.",
     "main": "lib/environments/node.js",
     "browser": "lib/environments/web.js",

--- a/packages/mo-fmt/package-lock.json
+++ b/packages/mo-fmt/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "mo-fmt",
-    "version": "0.12.5",
+    "version": "0.13.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mo-fmt",
-            "version": "0.12.5",
+            "version": "0.13.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^9.4.0",
                 "fast-glob": "^3.2.11",
                 "prettier": "2",
-                "prettier-plugin-motoko": "^0.12.5"
+                "prettier-plugin-motoko": "^0.13.0"
             },
             "bin": {
                 "mo-fmt": "bin/mo-fmt.js"
@@ -4653,9 +4653,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.12.5.tgz",
-            "integrity": "sha512-zNv17AQnNuLSKwS/bVIYeTV+gHE+D2ZP11X243g8fkyCu8OD2/bHZkms9HG1AUxJLp/qr0l8Qp3jAmxhhdZRZA==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.13.0.tgz",
+            "integrity": "sha512-6YnH95B5TrIsO3vNZ4fAEK40TWG8V2DoG1yT9Y0uCyoFl8ZNGTf8z3BzU4l+FgZa7AuJCJYN46Ti7ukA5aPFSA==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "prettier": "^2.7 || ^3.0"
@@ -9251,9 +9251,9 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.12.5.tgz",
-            "integrity": "sha512-zNv17AQnNuLSKwS/bVIYeTV+gHE+D2ZP11X243g8fkyCu8OD2/bHZkms9HG1AUxJLp/qr0l8Qp3jAmxhhdZRZA==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.13.0.tgz",
+            "integrity": "sha512-6YnH95B5TrIsO3vNZ4fAEK40TWG8V2DoG1yT9Y0uCyoFl8ZNGTf8z3BzU4l+FgZa7AuJCJYN46Ti7ukA5aPFSA==",
             "requires": {}
         },
         "pretty-format": {

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -22,7 +22,7 @@
         "commander": "^9.4.0",
         "fast-glob": "^3.2.11",
         "prettier": "2",
-        "prettier-plugin-motoko": "^0.12.5"
+        "prettier-plugin-motoko": "^0.13.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",

--- a/packages/mo-fmt/package.json
+++ b/packages/mo-fmt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mo-fmt",
-    "version": "0.12.5",
+    "version": "0.13.0",
     "description": "A standalone Motoko formatter CLI.",
     "main": "src/cli.js",
     "bin": {

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,13 @@ const options: Record<string, SupportOption> = {
         default: false,
         description: 'Remove extra lines around code blocks',
     },
+    motokoOrganizeImports: {
+        category: 'motoko',
+        type: 'boolean',
+        default: false,
+        description:
+            'Organize and sort import statements (groups by prefix: ic:, canister:, mo:, and relative paths)',
+    },
 };
 
 export default options;

--- a/src/printers/motoko-tt-ast/organizeImports.ts
+++ b/src/printers/motoko-tt-ast/organizeImports.ts
@@ -16,21 +16,21 @@ const WHITESPACE_TYPES = [
     'BlockComment',
 ];
 
-const isWhitespace = (tree: TokenTree): boolean => {
+function isWhitespace(tree: TokenTree): boolean {
     const token = getToken(tree);
     return !!token && WHITESPACE_TYPES.includes(token.token_type);
-};
+}
 
-const skipWhitespace = (trees: TokenTree[], start: number): number => {
+function skipWhitespace(trees: TokenTree[], start: number): number {
     let i = start;
     while (i < trees.length && isWhitespace(trees[i])) i++;
     return i;
-};
+}
 
-const isImportKeyword = (tree: TokenTree): boolean => {
+function isImportKeyword(tree: TokenTree): boolean {
     const token = getToken(tree);
     return !!token && token.token_type === 'Ident' && token.data === 'import';
-};
+}
 
 function extractImports(tree: TokenTree): ImportStatement[] {
     if (tree.token_tree_type !== 'Group') return [];

--- a/src/printers/motoko-tt-ast/organizeImports.ts
+++ b/src/printers/motoko-tt-ast/organizeImports.ts
@@ -327,7 +327,7 @@ export function transformOrganizeImports(tree: TokenTree): TokenTree {
             return tree;
         }
 
-        // Validate preservation
+        // Validate that all original imports are preserved in the organized version
         const organizedImports = extractImports(organizedTree);
         if (!validateImportsPreserved(imports, organizedImports)) {
             console.warn('Import data changed. Preserving original.');

--- a/src/printers/motoko-tt-ast/organizeImports.ts
+++ b/src/printers/motoko-tt-ast/organizeImports.ts
@@ -1,0 +1,373 @@
+import { Token, TokenTree } from '../../parsers/motoko-tt-parse/parse';
+import { getToken, getTokenText } from './utils';
+
+interface ImportStatement {
+    name?: string;
+    path: string;
+    fields: Array<[string, string]>;
+}
+
+const importGroups = [
+    { prefix: 'ic:' },
+    { prefix: 'canister:' },
+    { prefix: 'mo:' },
+    { prefix: '' }, // Everything else
+];
+
+/**
+ * Extracts all import statements from a token tree.
+ */
+export function extractImports(tree: TokenTree): ImportStatement[] {
+    if (tree.token_tree_type !== 'Group') {
+        return [];
+    }
+
+    const [trees, groupType] = tree.data;
+    if (groupType !== 'Unenclosed') {
+        return [];
+    }
+
+    const imports: ImportStatement[] = [];
+
+    // Walk through the top-level statements
+    for (let i = 0; i < trees.length; i++) {
+        const token = getToken(trees[i]);
+        if (!token || token.token_type !== 'Ident' || token.data !== 'import') {
+            continue;
+        }
+
+        // Parse the import statement
+        const importStmt = parseImportStatement(trees, i);
+        if (importStmt) {
+            imports.push(importStmt);
+        }
+    }
+
+    return imports;
+}
+
+/**
+ * Parses a single import statement starting at the given index.
+ * Returns the parsed import or null if parsing fails.
+ */
+function parseImportStatement(
+    trees: TokenTree[],
+    startIndex: number,
+): ImportStatement | null {
+    let i = startIndex + 1; // Skip 'import' keyword
+
+    // Skip whitespace
+    while (i < trees.length && isWhitespace(trees[i])) {
+        i++;
+    }
+
+    const import_: ImportStatement = {
+        path: '',
+        fields: [],
+    };
+
+    // Check if it's a destructured import (starts with '{')
+    if (i < trees.length && trees[i].token_tree_type === 'Group') {
+        const [groupTrees, groupType] = trees[i].data;
+        if (groupType === 'Curly') {
+            // Parse destructured fields
+            import_.fields = parseDestructuredFields(groupTrees);
+            i++;
+        }
+    } else {
+        // Parse module name
+        const nameToken = getToken(trees[i]);
+        if (nameToken && nameToken.token_type === 'Ident') {
+            import_.name = nameToken.data;
+            i++;
+        }
+    }
+
+    // Skip whitespace
+    while (i < trees.length && isWhitespace(trees[i])) {
+        i++;
+    }
+
+    // Parse import path (string literal)
+    if (i < trees.length) {
+        const pathToken = getToken(trees[i]);
+        if (pathToken && pathToken.token_type === 'Literal') {
+            const [text, literalType] = pathToken.data;
+            if (literalType === 'Text') {
+                // Remove quotes from the path
+                import_.path = JSON.parse(text);
+            }
+        }
+    }
+
+    return import_.path ? import_ : null;
+}
+
+/**
+ * Parses destructured import fields from a curly-braced group.
+ */
+function parseDestructuredFields(trees: TokenTree[]): Array<[string, string]> {
+    const fields: Array<[string, string]> = [];
+    let currentName: string | null = null;
+    let expectingAlias = false;
+
+    for (let i = 0; i < trees.length; i++) {
+        const token = getToken(trees[i]);
+        if (!token || isWhitespace(trees[i])) {
+            continue;
+        }
+
+        if (token.token_type === 'Ident') {
+            if (expectingAlias) {
+                // This is the alias
+                if (currentName) {
+                    fields.push([currentName, token.data]);
+                    currentName = null;
+                    expectingAlias = false;
+                }
+            } else {
+                // Save previous field if exists
+                if (currentName) {
+                    fields.push([currentName, currentName]);
+                }
+                currentName = token.data;
+            }
+        } else if (token.token_type === 'Assign' && token.data === '=') {
+            expectingAlias = true;
+        } else if (token.token_type === 'Delim') {
+            // Delimiter - save current field
+            if (currentName) {
+                fields.push([currentName, currentName]);
+                currentName = null;
+                expectingAlias = false;
+            }
+        }
+    }
+
+    // Add last field
+    if (currentName) {
+        fields.push([currentName, currentName]);
+    }
+
+    return fields;
+}
+
+/**
+ * Checks if a token tree represents whitespace or comments.
+ */
+function isWhitespace(tree: TokenTree): boolean {
+    const token = getToken(tree);
+    return (
+        !!token &&
+        ['Space', 'Line', 'MultiLine', 'LineComment', 'BlockComment'].includes(
+            token.token_type,
+        )
+    );
+}
+
+/**
+ * Organizes and formats import statements.
+ */
+export function organizeImports(imports: ImportStatement[]): string {
+    const groupParts: string[][] = importGroups.map(() => []);
+
+    // Combine imports with the same path
+    const combinedImports: Record<
+        string,
+        { names: string[]; fields: Array<[string, string]> }
+    > = {};
+
+    imports.forEach((imp) => {
+        const combined =
+            combinedImports[imp.path] ||
+            (combinedImports[imp.path] = { names: [], fields: [] });
+
+        if (imp.name) {
+            combined.names.push(imp.name);
+        }
+        combined.fields.push(...imp.fields);
+    });
+
+    // Sort and print imports
+    Object.entries(combinedImports)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .forEach(([path, { names, fields }]) => {
+            let groupIndex = importGroups.findIndex((g) =>
+                path.startsWith(g.prefix),
+            );
+            if (groupIndex === -1) {
+                groupIndex = importGroups.length - 1;
+            }
+            const parts = groupParts[groupIndex];
+
+            // Add module-level imports
+            names.forEach((name) => {
+                parts.push(`import ${name} ${JSON.stringify(path)};`);
+            });
+
+            // Add destructured imports
+            if (fields.length) {
+                // Remove duplicates and sort
+                const uniqueFields = Array.from(
+                    new Map(
+                        fields.map(([name, alias]) => [
+                            `${name}:${alias}`,
+                            [name, alias],
+                        ]),
+                    ).values(),
+                );
+
+                uniqueFields.sort((a, b) => {
+                    // Sort by name, then alias
+                    return (
+                        a[0].localeCompare(b[0]) ||
+                        (a[1] || a[0]).localeCompare(b[1] || b[0])
+                    );
+                });
+
+                const fieldStr = uniqueFields
+                    .map(([name, alias]) =>
+                        !alias || name === alias ? name : `${name} = ${alias}`,
+                    )
+                    .join('; ');
+
+                parts.push(`import { ${fieldStr} } ${JSON.stringify(path)};`);
+            }
+        });
+
+    // Join groups with double newlines
+    return groupParts
+        .map((p) => p.join('\n'))
+        .filter((s) => s.length > 0)
+        .join('\n\n');
+}
+
+/**
+ * Finds the range of import statements in the token tree.
+ * Returns [startIndex, endIndex] or null if no imports found.
+ */
+export function findImportRange(tree: TokenTree): [number, number] | null {
+    if (tree.token_tree_type !== 'Group') {
+        return null;
+    }
+
+    const [trees, groupType] = tree.data;
+    if (groupType !== 'Unenclosed') {
+        return null;
+    }
+
+    let firstImportIndex = -1;
+    let lastImportIndex = -1;
+
+    for (let i = 0; i < trees.length; i++) {
+        const token = getToken(trees[i]);
+        if (token && token.token_type === 'Ident' && token.data === 'import') {
+            if (firstImportIndex === -1) {
+                firstImportIndex = i;
+            }
+
+            // Find the end of this import statement (semicolon or newline)
+            let j = i + 1;
+            while (j < trees.length) {
+                const nextToken = getToken(trees[j]);
+                if (
+                    nextToken &&
+                    (nextToken.token_type === 'Delim' ||
+                        nextToken.token_type === 'MultiLine')
+                ) {
+                    lastImportIndex = j;
+                    break;
+                }
+                j++;
+            }
+
+            // Move to after this import statement
+            i = j;
+        } else if (firstImportIndex !== -1 && !isWhitespace(trees[i])) {
+            // Found a non-import, non-whitespace token after imports
+            break;
+        }
+    }
+
+    return firstImportIndex !== -1 && lastImportIndex !== -1
+        ? [firstImportIndex, lastImportIndex]
+        : null;
+}
+
+/**
+ * Transforms a token tree by organizing its import statements.
+ * Returns a new tree with organized imports.
+ */
+export function transformTreeWithOrganizedImports(tree: TokenTree): TokenTree {
+    if (tree.token_tree_type !== 'Group') {
+        return tree;
+    }
+
+    const [trees, groupType, pair] = tree.data;
+    if (groupType !== 'Unenclosed') {
+        return tree;
+    }
+
+    // Extract imports
+    const imports = extractImports(tree);
+    if (imports.length === 0) {
+        return tree;
+    }
+
+    // Find import range
+    const range = findImportRange(tree);
+    if (!range) {
+        return tree;
+    }
+
+    const [startIndex, endIndex] = range;
+
+    // Generate organized import text
+    const organizedText = organizeImports(imports);
+
+    // Parse organized imports back into token trees
+    // We'll use the WASM parser here
+    const wasm = require('../../wasm').default;
+    const organizedTree = wasm.parse_token_tree(organizedText.trim());
+
+    // Extract the import tokens from the organized tree
+    let organizedImportTrees: TokenTree[] = [];
+    if (organizedTree.token_tree_type === 'Group') {
+        organizedImportTrees = organizedTree.data[0];
+    }
+
+    // Build new tree: keep everything before imports, add organized imports, keep everything after imports
+    const newTrees: TokenTree[] = [
+        ...trees.slice(0, startIndex),
+        ...organizedImportTrees,
+    ];
+
+    // Add whitespace separation if there's content after imports
+    if (endIndex + 1 < trees.length) {
+        // Find the first non-whitespace token after imports
+        let nextNonWhitespace = endIndex + 1;
+        while (
+            nextNonWhitespace < trees.length &&
+            isWhitespace(trees[nextNonWhitespace])
+        ) {
+            nextNonWhitespace++;
+        }
+
+        if (nextNonWhitespace < trees.length) {
+            // Add double newline after imports
+            newTrees.push({
+                token_tree_type: 'Token',
+                data: [
+                    { token_type: 'MultiLine', data: '\n\n' },
+                    { line: 0, col: 0, span: [0, 0] },
+                ],
+            });
+            newTrees.push(...trees.slice(nextNonWhitespace));
+        }
+    }
+
+    return {
+        token_tree_type: 'Group',
+        data: [newTrees, groupType, pair],
+    };
+}

--- a/src/printers/motoko-tt-ast/organizeImports.ts
+++ b/src/printers/motoko-tt-ast/organizeImports.ts
@@ -1,5 +1,5 @@
 import { Token, TokenTree } from '../../parsers/motoko-tt-parse/parse';
-import { getToken, getTokenText } from './utils';
+import { getToken } from './utils';
 
 interface ImportStatement {
     name?: string;
@@ -7,354 +7,339 @@ interface ImportStatement {
     fields: Array<[string, string]>;
 }
 
-const importGroups = [
-    { prefix: 'ic:' },
-    { prefix: 'canister:' },
-    { prefix: 'mo:' },
-    { prefix: '' }, // Everything else
+const IMPORT_GROUPS = ['ic:', 'canister:', 'mo:', ''];
+const WHITESPACE_TYPES = [
+    'Space',
+    'Line',
+    'MultiLine',
+    'LineComment',
+    'BlockComment',
 ];
 
-/**
- * Extracts all import statements from a token tree.
- */
-export function extractImports(tree: TokenTree): ImportStatement[] {
-    if (tree.token_tree_type !== 'Group') {
-        return [];
-    }
+const isWhitespace = (tree: TokenTree): boolean => {
+    const token = getToken(tree);
+    return !!token && WHITESPACE_TYPES.includes(token.token_type);
+};
 
+const skipWhitespace = (trees: TokenTree[], start: number): number => {
+    let i = start;
+    while (i < trees.length && isWhitespace(trees[i])) i++;
+    return i;
+};
+
+const isImportKeyword = (tree: TokenTree): boolean => {
+    const token = getToken(tree);
+    return !!token && token.token_type === 'Ident' && token.data === 'import';
+};
+
+function extractImports(tree: TokenTree): ImportStatement[] {
+    if (tree.token_tree_type !== 'Group') return [];
     const [trees, groupType] = tree.data;
-    if (groupType !== 'Unenclosed') {
-        return [];
-    }
+    if (groupType !== 'Unenclosed') return [];
 
-    const imports: ImportStatement[] = [];
-
-    // Walk through the top-level statements
-    for (let i = 0; i < trees.length; i++) {
-        const token = getToken(trees[i]);
-        if (!token || token.token_type !== 'Ident' || token.data !== 'import') {
-            continue;
-        }
-
-        // Parse the import statement
-        const importStmt = parseImportStatement(trees, i);
-        if (importStmt) {
-            imports.push(importStmt);
-        }
-    }
-
-    return imports;
+    return trees
+        .map((tree, i) =>
+            isImportKeyword(tree) ? parseImportStatement(trees, i) : null,
+        )
+        .filter((imp): imp is ImportStatement => !!imp?.path);
 }
 
-/**
- * Parses a single import statement starting at the given index.
- * Returns the parsed import or null if parsing fails.
- */
 function parseImportStatement(
     trees: TokenTree[],
     startIndex: number,
 ): ImportStatement | null {
-    let i = startIndex + 1; // Skip 'import' keyword
+    try {
+        let i = skipWhitespace(trees, startIndex + 1);
+        if (i >= trees.length) return null;
 
-    // Skip whitespace
-    while (i < trees.length && isWhitespace(trees[i])) {
-        i++;
-    }
+        const import_: ImportStatement = { path: '', fields: [] };
 
-    const import_: ImportStatement = {
-        path: '',
-        fields: [],
-    };
-
-    // Check if it's a destructured import (starts with '{')
-    if (i < trees.length && trees[i].token_tree_type === 'Group') {
-        const [groupTrees, groupType] = trees[i].data;
-        if (groupType === 'Curly') {
-            // Parse destructured fields
-            import_.fields = parseDestructuredFields(groupTrees);
-            i++;
+        // Check for destructured import
+        if (trees[i].token_tree_type === 'Group') {
+            const [groupTrees, groupType] = trees[i].data;
+            if (groupType === 'Curly') {
+                import_.fields = parseDestructuredFields(groupTrees);
+                i++;
+            }
+        } else {
+            const nameToken = getToken(trees[i]);
+            if (nameToken?.token_type === 'Ident') {
+                import_.name = nameToken.data;
+                i++;
+            }
         }
-    } else {
-        // Parse module name
-        const nameToken = getToken(trees[i]);
-        if (nameToken && nameToken.token_type === 'Ident') {
-            import_.name = nameToken.data;
-            i++;
-        }
-    }
 
-    // Skip whitespace
-    while (i < trees.length && isWhitespace(trees[i])) {
-        i++;
-    }
+        i = skipWhitespace(trees, i);
 
-    // Parse import path (string literal)
-    if (i < trees.length) {
+        // Parse import path
         const pathToken = getToken(trees[i]);
-        if (pathToken && pathToken.token_type === 'Literal') {
+        if (pathToken?.token_type === 'Literal') {
             const [text, literalType] = pathToken.data;
             if (literalType === 'Text') {
-                // Remove quotes from the path
-                import_.path = JSON.parse(text);
+                try {
+                    import_.path = JSON.parse(text);
+                } catch {
+                    return null;
+                }
             }
         }
-    }
 
-    return import_.path ? import_ : null;
+        return import_.path ? import_ : null;
+    } catch {
+        return null;
+    }
 }
 
-/**
- * Parses destructured import fields from a curly-braced group.
- */
 function parseDestructuredFields(trees: TokenTree[]): Array<[string, string]> {
     const fields: Array<[string, string]> = [];
-    let currentName: string | null = null;
-    let expectingAlias = false;
+    let current: string | null = null;
+    let expectAlias = false;
 
-    for (let i = 0; i < trees.length; i++) {
-        const token = getToken(trees[i]);
-        if (!token || isWhitespace(trees[i])) {
-            continue;
-        }
+    for (const tree of trees) {
+        const token = getToken(tree);
+        if (!token || isWhitespace(tree)) continue;
 
         if (token.token_type === 'Ident') {
-            if (expectingAlias) {
-                // This is the alias
-                if (currentName) {
-                    fields.push([currentName, token.data]);
-                    currentName = null;
-                    expectingAlias = false;
-                }
+            if (expectAlias && current) {
+                fields.push([current, token.data]);
+                current = null;
+                expectAlias = false;
             } else {
-                // Save previous field if exists
-                if (currentName) {
-                    fields.push([currentName, currentName]);
-                }
-                currentName = token.data;
+                if (current) fields.push([current, current]);
+                current = token.data;
             }
         } else if (token.token_type === 'Assign' && token.data === '=') {
-            expectingAlias = true;
+            expectAlias = true;
         } else if (token.token_type === 'Delim') {
-            // Delimiter - save current field
-            if (currentName) {
-                fields.push([currentName, currentName]);
-                currentName = null;
-                expectingAlias = false;
-            }
+            if (current) fields.push([current, current]);
+            current = null;
+            expectAlias = false;
         }
     }
 
-    // Add last field
-    if (currentName) {
-        fields.push([currentName, currentName]);
-    }
-
+    if (current) fields.push([current, current]);
     return fields;
 }
 
-/**
- * Checks if a token tree represents whitespace or comments.
- */
-function isWhitespace(tree: TokenTree): boolean {
-    const token = getToken(tree);
-    return (
-        !!token &&
-        ['Space', 'Line', 'MultiLine', 'LineComment', 'BlockComment'].includes(
-            token.token_type,
-        )
-    );
-}
-
-/**
- * Organizes and formats import statements.
- */
-export function organizeImports(imports: ImportStatement[]): string {
-    const groupParts: string[][] = importGroups.map(() => []);
-
-    // Combine imports with the same path
-    const combinedImports: Record<
+function organizeImports(imports: ImportStatement[]): string {
+    // Combine imports by path
+    const combined = new Map<
         string,
-        { names: string[]; fields: Array<[string, string]> }
-    > = {};
+        { names: Set<string>; fields: Array<[string, string]> }
+    >();
 
-    imports.forEach((imp) => {
-        const combined =
-            combinedImports[imp.path] ||
-            (combinedImports[imp.path] = { names: [], fields: [] });
+    for (const imp of imports) {
+        const entry = combined.get(imp.path) || {
+            names: new Set<string>(),
+            fields: [],
+        };
+        if (!combined.has(imp.path)) combined.set(imp.path, entry);
+        if (imp.name) entry.names.add(imp.name);
+        entry.fields.push(...imp.fields);
+    }
 
-        if (imp.name) {
-            combined.names.push(imp.name);
+    // Group by prefix
+    const groups = IMPORT_GROUPS.map(() => [] as string[]);
+
+    for (const [path, { names, fields }] of Array.from(combined).sort((a, b) =>
+        a[0].localeCompare(b[0]),
+    )) {
+        const groupIndex = IMPORT_GROUPS.findIndex((prefix) =>
+            path.startsWith(prefix),
+        );
+        const group =
+            groups[groupIndex === -1 ? groups.length - 1 : groupIndex];
+
+        // Module-level imports
+        for (const name of Array.from(names).sort()) {
+            group.push(`import ${name} ${JSON.stringify(path)};`);
         }
-        combined.fields.push(...imp.fields);
-    });
 
-    // Sort and print imports
-    Object.entries(combinedImports)
-        .sort((a, b) => a[0].localeCompare(b[0]))
-        .forEach(([path, { names, fields }]) => {
-            let groupIndex = importGroups.findIndex((g) =>
-                path.startsWith(g.prefix),
+        // Destructured imports
+        if (fields.length) {
+            const uniqueFields = Array.from(
+                new Map(
+                    fields.map(([n, a]) => [`${n}:${a}`, [n, a]] as const),
+                ).values(),
+            ).sort(
+                (a, b) => a[0].localeCompare(b[0]) || a[1].localeCompare(b[1]),
             );
-            if (groupIndex === -1) {
-                groupIndex = importGroups.length - 1;
-            }
-            const parts = groupParts[groupIndex];
 
-            // Add module-level imports
-            names.forEach((name) => {
-                parts.push(`import ${name} ${JSON.stringify(path)};`);
-            });
+            const fieldStr = uniqueFields
+                .map(([n, a]) => (n === a ? n : `${n} = ${a}`))
+                .join('; ');
 
-            // Add destructured imports
-            if (fields.length) {
-                // Remove duplicates and sort
-                const uniqueFields = Array.from(
-                    new Map(
-                        fields.map(([name, alias]) => [
-                            `${name}:${alias}`,
-                            [name, alias],
-                        ]),
-                    ).values(),
-                );
+            group.push(`import { ${fieldStr} } ${JSON.stringify(path)};`);
+        }
+    }
 
-                uniqueFields.sort((a, b) => {
-                    // Sort by name, then alias
-                    return (
-                        a[0].localeCompare(b[0]) ||
-                        (a[1] || a[0]).localeCompare(b[1] || b[0])
-                    );
-                });
-
-                const fieldStr = uniqueFields
-                    .map(([name, alias]) =>
-                        !alias || name === alias ? name : `${name} = ${alias}`,
-                    )
-                    .join('; ');
-
-                parts.push(`import { ${fieldStr} } ${JSON.stringify(path)};`);
-            }
-        });
-
-    // Join groups with double newlines
-    return groupParts
-        .map((p) => p.join('\n'))
-        .filter((s) => s.length > 0)
+    return groups
+        .filter((g) => g.length)
+        .map((g) => g.join('\n'))
         .join('\n\n');
 }
 
-/**
- * Finds the range of import statements in the token tree.
- * Returns [startIndex, endIndex] or null if no imports found.
- */
-export function findImportRange(tree: TokenTree): [number, number] | null {
-    if (tree.token_tree_type !== 'Group') {
-        return null;
-    }
-
+function findImportRange(tree: TokenTree): [number, number] | null {
+    if (tree.token_tree_type !== 'Group') return null;
     const [trees, groupType] = tree.data;
-    if (groupType !== 'Unenclosed') {
-        return null;
-    }
+    if (groupType !== 'Unenclosed') return null;
 
-    let firstImportIndex = -1;
-    let lastImportIndex = -1;
+    let first = -1;
+    let last = -1;
 
     for (let i = 0; i < trees.length; i++) {
-        const token = getToken(trees[i]);
-        if (token && token.token_type === 'Ident' && token.data === 'import') {
-            if (firstImportIndex === -1) {
-                firstImportIndex = i;
-            }
+        if (isImportKeyword(trees[i])) {
+            if (first === -1) first = i;
 
-            // Find the end of this import statement (semicolon or newline)
+            // Find end of this import statement
             let j = i + 1;
             while (j < trees.length) {
-                const nextToken = getToken(trees[j]);
+                const token = getToken(trees[j]);
                 if (
-                    nextToken &&
-                    (nextToken.token_type === 'Delim' ||
-                        nextToken.token_type === 'MultiLine')
+                    token &&
+                    (token.token_type === 'Delim' ||
+                        token.token_type === 'MultiLine')
                 ) {
-                    lastImportIndex = j;
+                    last = j;
                     break;
                 }
                 j++;
             }
-
-            // Move to after this import statement
             i = j;
-        } else if (firstImportIndex !== -1 && !isWhitespace(trees[i])) {
-            // Found a non-import, non-whitespace token after imports
-            break;
+        } else if (first !== -1 && !isWhitespace(trees[i])) {
+            break; // Found non-import after imports
         }
     }
 
-    return firstImportIndex !== -1 && lastImportIndex !== -1
-        ? [firstImportIndex, lastImportIndex]
-        : null;
+    return first !== -1 && last !== -1 ? [first, last] : null;
 }
 
-/**
- * Transforms a token tree by organizing its import statements.
- * Returns a new tree with organized imports.
- */
-export function transformTreeWithOrganizedImports(tree: TokenTree): TokenTree {
-    if (tree.token_tree_type !== 'Group') {
-        return tree;
-    }
+function validateImportsPreserved(
+    original: ImportStatement[],
+    organized: ImportStatement[],
+): boolean {
+    const groupByPath = (imports: ImportStatement[]) => {
+        const map = new Map<
+            string,
+            { names: Set<string>; fields: Set<string> }
+        >();
+        for (const imp of imports) {
+            const entry = map.get(imp.path) || {
+                names: new Set<string>(),
+                fields: new Set<string>(),
+            };
+            if (!map.has(imp.path)) map.set(imp.path, entry);
+            if (imp.name) entry.names.add(imp.name);
+            for (const [name, alias] of imp.fields) {
+                entry.fields.add(`${name}:${alias}`);
+            }
+        }
+        return map;
+    };
 
-    const [trees, groupType, pair] = tree.data;
-    if (groupType !== 'Unenclosed') {
-        return tree;
-    }
+    const origMap = groupByPath(original);
+    const orgMap = groupByPath(organized);
 
-    // Extract imports
-    const imports = extractImports(tree);
-    if (imports.length === 0) {
-        return tree;
-    }
+    for (const [path, orig] of origMap) {
+        // Skip empty imports (intentionally dropped)
+        if (orig.names.size === 0 && orig.fields.size === 0) continue;
 
-    // Find import range
-    const range = findImportRange(tree);
-    if (!range) {
-        return tree;
-    }
-
-    const [startIndex, endIndex] = range;
-
-    // Generate organized import text
-    const organizedText = organizeImports(imports);
-
-    // Parse organized imports back into token trees
-    // We'll use the WASM parser here
-    const wasm = require('../../wasm').default;
-    const organizedTree = wasm.parse_token_tree(organizedText.trim());
-
-    // Extract the import tokens from the organized tree
-    let organizedImportTrees: TokenTree[] = [];
-    if (organizedTree.token_tree_type === 'Group') {
-        organizedImportTrees = organizedTree.data[0];
-    }
-
-    // Build new tree: keep everything before imports, add organized imports, keep everything after imports
-    const newTrees: TokenTree[] = [
-        ...trees.slice(0, startIndex),
-        ...organizedImportTrees,
-    ];
-
-    // Add whitespace separation if there's content after imports
-    if (endIndex + 1 < trees.length) {
-        // Find the first non-whitespace token after imports
-        let nextNonWhitespace = endIndex + 1;
-        while (
-            nextNonWhitespace < trees.length &&
-            isWhitespace(trees[nextNonWhitespace])
-        ) {
-            nextNonWhitespace++;
+        const org = orgMap.get(path);
+        if (!org) {
+            console.warn(`Path ${path} missing after organizing`);
+            return false;
         }
 
-        if (nextNonWhitespace < trees.length) {
-            // Add double newline after imports
+        for (const name of orig.names) {
+            if (!org.names.has(name)) {
+                console.warn(
+                    `Name "${name}" for path ${path} missing after organizing`,
+                );
+                return false;
+            }
+        }
+
+        for (const field of orig.fields) {
+            if (!org.fields.has(field)) {
+                console.warn(
+                    `Field "${field}" for path ${path} missing after organizing`,
+                );
+                return false;
+            }
+        }
+    }
+
+    for (const path of orgMap.keys()) {
+        if (!origMap.has(path)) {
+            console.warn(`Unexpected path ${path} added after organizing`);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export function transformOrganizeImports(tree: TokenTree): TokenTree {
+    if (tree.token_tree_type !== 'Group') return tree;
+    const [trees, groupType, pair] = tree.data;
+    if (groupType !== 'Unenclosed') return tree;
+
+    try {
+        const range = findImportRange(tree);
+        if (!range) return tree;
+
+        const [start, end] = range;
+        const origCount = trees
+            .slice(start, end + 1)
+            .filter(isImportKeyword).length;
+        if (origCount === 0) return tree;
+
+        const imports = extractImports(tree);
+        const validCount = imports.length;
+
+        // If we found fewer valid imports than original, some are malformed
+        if (validCount < origCount) {
+            console.warn(
+                `Found ${origCount} imports but only ${validCount} parsed. Preserving original.`,
+            );
+            return tree;
+        }
+
+        const organizedText = organizeImports(imports);
+        if (!organizedText.trim()) return tree;
+
+        // Parse organized imports back
+        const wasm = require('../../wasm').default;
+        const organizedTree = wasm.parse_token_tree(organizedText.trim());
+
+        if (organizedTree.token_tree_type !== 'Group') {
+            console.warn(
+                'Failed to parse organized imports. Preserving original.',
+            );
+            return tree;
+        }
+
+        const organizedTrees = organizedTree.data[0];
+        const organizedCount = organizedTrees.filter(isImportKeyword).length;
+
+        if (organizedCount === 0) {
+            console.warn('No imports in organized tree. Preserving original.');
+            return tree;
+        }
+
+        // Validate preservation
+        const organizedImports = extractImports(organizedTree);
+        if (!validateImportsPreserved(imports, organizedImports)) {
+            console.warn('Import data changed. Preserving original.');
+            return tree;
+        }
+
+        // Build new tree
+        const newTrees = [...trees.slice(0, start), ...organizedTrees];
+
+        // Add spacing if there's content after imports
+        const nextNonWs = skipWhitespace(trees, end + 1);
+        if (nextNonWs < trees.length) {
             newTrees.push({
                 token_tree_type: 'Token',
                 data: [
@@ -362,12 +347,15 @@ export function transformTreeWithOrganizedImports(tree: TokenTree): TokenTree {
                     { line: 0, col: 0, span: [0, 0] },
                 ],
             });
-            newTrees.push(...trees.slice(nextNonWhitespace));
+            newTrees.push(...trees.slice(nextNonWs));
         }
-    }
 
-    return {
-        token_tree_type: 'Group',
-        data: [newTrees, groupType, pair],
-    };
+        return { token_tree_type: 'Group', data: [newTrees, groupType, pair] };
+    } catch (error) {
+        console.warn(
+            'Error organizing imports:',
+            error instanceof Error ? error.message : String(error),
+        );
+        return tree;
+    }
 }

--- a/src/printers/motoko-tt-ast/organizeImports.ts
+++ b/src/printers/motoko-tt-ast/organizeImports.ts
@@ -246,35 +246,19 @@ function validateImportsPreserved(
         if (orig.names.size === 0 && orig.fields.size === 0) continue;
 
         const org = orgMap.get(path);
-        if (!org) {
-            console.warn(`Path ${path} missing after organizing`);
-            return false;
-        }
+        if (!org) return false;
 
         for (const name of orig.names) {
-            if (!org.names.has(name)) {
-                console.warn(
-                    `Name "${name}" for path ${path} missing after organizing`,
-                );
-                return false;
-            }
+            if (!org.names.has(name)) return false;
         }
 
         for (const field of orig.fields) {
-            if (!org.fields.has(field)) {
-                console.warn(
-                    `Field "${field}" for path ${path} missing after organizing`,
-                );
-                return false;
-            }
+            if (!org.fields.has(field)) return false;
         }
     }
 
     for (const path of orgMap.keys()) {
-        if (!origMap.has(path)) {
-            console.warn(`Unexpected path ${path} added after organizing`);
-            return false;
-        }
+        if (!origMap.has(path)) return false;
     }
 
     return true;
@@ -324,9 +308,6 @@ export function transformOrganizeImports(tree: TokenTree): TokenTree {
 
         // If we found fewer valid imports than original, some are malformed
         if (validCount < origCount) {
-            console.warn(
-                `Found ${origCount} imports but only ${validCount} parsed. Preserving original.`,
-            );
             return tree;
         }
 
@@ -335,9 +316,6 @@ export function transformOrganizeImports(tree: TokenTree): TokenTree {
 
         const organizedTree = wasm.parse_token_tree(organizedText.trim());
         if (organizedTree.token_tree_type !== 'Group') {
-            console.warn(
-                'Failed to parse organized imports. Preserving original.',
-            );
             return tree;
         }
 
@@ -345,14 +323,12 @@ export function transformOrganizeImports(tree: TokenTree): TokenTree {
         const organizedCount = organizedTrees.filter(isImportKeyword).length;
 
         if (organizedCount === 0) {
-            console.warn('No imports in organized tree. Preserving original.');
             return tree;
         }
 
         // Validate that all original imports are preserved in the organized version
         const organizedImports = extractImports(organizedTree);
         if (!validateImportsPreserved(imports, organizedImports)) {
-            console.warn('Import data changed. Preserving original.');
             return tree;
         }
 
@@ -391,11 +367,7 @@ export function transformOrganizeImports(tree: TokenTree): TokenTree {
         }
 
         return { token_tree_type: 'Group', data: [newTrees, groupType, pair] };
-    } catch (error) {
-        console.warn(
-            'Error organizing imports:',
-            error instanceof Error ? error.message : String(error),
-        );
+    } catch {
         return tree;
     }
 }

--- a/src/printers/motoko-tt-ast/organizeImports.ts
+++ b/src/printers/motoko-tt-ast/organizeImports.ts
@@ -1,5 +1,6 @@
+import wasm from '../../wasm';
 import { Token, TokenTree } from '../../parsers/motoko-tt-parse/parse';
-import { getToken } from './utils';
+import { getToken, getTokenText, getTokenTreeText } from './utils';
 
 interface ImportStatement {
     name?: string;
@@ -279,6 +280,30 @@ function validateImportsPreserved(
     return true;
 }
 
+function collectComments(
+    trees: TokenTree[],
+    start: number,
+    end: number,
+): string[] {
+    const comments: string[] = [];
+    for (let i = start; i <= end && i < trees.length; i++) {
+        const token = getToken(trees[i]);
+        if (
+            token &&
+            (token.token_type === 'LineComment' ||
+                token.token_type === 'BlockComment')
+        ) {
+            comments.push(getTokenText(token));
+        } else if (
+            trees[i].token_tree_type === 'Group' &&
+            trees[i].data[1] === 'Comment'
+        ) {
+            comments.push(getTokenTreeText(trees[i]));
+        }
+    }
+    return comments;
+}
+
 export function transformOrganizeImports(tree: TokenTree): TokenTree {
     if (tree.token_tree_type !== 'Group') return tree;
     const [trees, groupType, pair] = tree.data;
@@ -308,10 +333,7 @@ export function transformOrganizeImports(tree: TokenTree): TokenTree {
         const organizedText = organizeImports(imports);
         if (!organizedText.trim()) return tree;
 
-        // Parse organized imports back
-        const wasm = require('../../wasm').default;
         const organizedTree = wasm.parse_token_tree(organizedText.trim());
-
         if (organizedTree.token_tree_type !== 'Group') {
             console.warn(
                 'Failed to parse organized imports. Preserving original.',
@@ -334,11 +356,29 @@ export function transformOrganizeImports(tree: TokenTree): TokenTree {
             return tree;
         }
 
+        // Collect comments from the import range and trailing whitespace
+        const nextNonWs = skipWhitespace(trees, end + 1);
+        const comments = collectComments(trees, start, nextNonWs - 1);
+
+        // Build final trees, preserving comments after organized imports
+        let finalTrees: TokenTree[];
+        if (comments.length > 0) {
+            const finalText =
+                organizedText.trim() + '\n\n' + comments.join('\n');
+            const finalTree = wasm.parse_token_tree(finalText);
+            if (finalTree.token_tree_type === 'Group') {
+                finalTrees = finalTree.data[0];
+            } else {
+                finalTrees = organizedTrees;
+            }
+        } else {
+            finalTrees = organizedTrees;
+        }
+
         // Build new tree
-        const newTrees = [...trees.slice(0, start), ...organizedTrees];
+        const newTrees = [...trees.slice(0, start), ...finalTrees];
 
         // Add spacing if there's content after imports
-        const nextNonWs = skipWhitespace(trees, end + 1);
         if (nextNonWs < trees.length) {
             newTrees.push({
                 token_tree_type: 'Token',

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -116,12 +116,12 @@ export default function print(
     if (tree === null) {
         return '';
     }
-    
+
     // Organize imports if option is enabled
-    if ((options as any).motokoOrganizeImports && tree.token_tree_type === 'Group') {
+    if (options.motokoOrganizeImports && tree.token_tree_type === 'Group') {
         tree = transformOrganizeImports(tree);
     }
-    
+
     const doc = printTokenTree(tree, path, options, print, args);
     return doc || (Array.isArray(doc) && doc.length)
         ? [doc, literallineWithoutBreakParent]

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -11,7 +11,7 @@ import {
     getTokenTreeText,
     withoutLineBreaks,
 } from './utils';
-import { transformTreeWithOrganizedImports } from './organizeImports';
+import { transformOrganizeImports } from './organizeImports';
 
 export type Space =
     | (
@@ -119,7 +119,7 @@ export default function print(
     
     // Organize imports if option is enabled
     if ((options as any).motokoOrganizeImports && tree.token_tree_type === 'Group') {
-        tree = transformTreeWithOrganizedImports(tree);
+        tree = transformOrganizeImports(tree);
     }
     
     const doc = printTokenTree(tree, path, options, print, args);

--- a/src/printers/motoko-tt-ast/print.ts
+++ b/src/printers/motoko-tt-ast/print.ts
@@ -11,6 +11,7 @@ import {
     getTokenTreeText,
     withoutLineBreaks,
 } from './utils';
+import { transformTreeWithOrganizedImports } from './organizeImports';
 
 export type Space =
     | (
@@ -111,15 +112,20 @@ export default function print(
     print: (path: AstPath<TokenTree>) => Doc,
     args?: unknown,
 ): Doc {
-    const tree = path.getValue();
+    let tree = path.getValue();
     if (tree === null) {
         return '';
-    } else {
-        const doc = printTokenTree(tree, path, options, print, args);
-        return doc || (Array.isArray(doc) && doc.length)
-            ? [doc, literallineWithoutBreakParent]
-            : doc;
     }
+    
+    // Organize imports if option is enabled
+    if ((options as any).motokoOrganizeImports && tree.token_tree_type === 'Group') {
+        tree = transformTreeWithOrganizedImports(tree);
+    }
+    
+    const doc = printTokenTree(tree, path, options, print, args);
+    return doc || (Array.isArray(doc) && doc.length)
+        ? [doc, literallineWithoutBreakParent]
+        : doc;
 }
 
 function shouldSkipTokenTree(tree: TokenTree): boolean {

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -704,8 +704,11 @@ public type T = {
         expect(await format('{\n\n1;\n2;\n\n3;\n\n}\n', options)).toEqual(
             '{\n  1;\n  2;\n\n  3;\n};\n',
         );
-        expect(await format('actor {\n\nfunc f() {\n\nlet a = 0;\n\n}\n\n}\n', options)).toEqual(
-            'actor {\n  func f() {\n    let a = 0;\n  };\n};\n',
-        );
+        expect(
+            await format(
+                'actor {\n\nfunc f() {\n\nlet a = 0;\n\n}\n\n}\n',
+                options,
+            ),
+        ).toEqual('actor {\n  func f() {\n    let a = 0;\n  };\n};\n');
     });
 });

--- a/tests/organizeImports.test.ts
+++ b/tests/organizeImports.test.ts
@@ -164,6 +164,9 @@ actor {}`;
         const expected = `import Array "mo:base/Array";
 import Text "mo:base/Text";
 
+// Array utilities
+// Text utilities
+
 actor {};\n`;
         expect(await format(input, organizeImportsOptions)).toEqual(expected);
     });
@@ -177,6 +180,26 @@ actor {}`;
         const expected = `/* Core imports */
 import Array "mo:base/Array";
 import Text "mo:base/Text";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('comments between imports are preserved', async () => {
+        const input = `// Base library imports
+import Text "mo:base/Text";
+// Utility imports
+import Utils "./utils";
+import Array "mo:base/Array";
+
+actor {}`;
+        const expected = `// Base library imports
+import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+import Utils "./utils";
+
+// Utility imports
 
 actor {};\n`;
         expect(await format(input, organizeImportsOptions)).toEqual(expected);
@@ -303,6 +326,8 @@ actor {
 }`;
         const expected = `import Array "mo:base/Array";
 import Text "mo:base/Text";
+
+// Main actor
 
 actor {
   public func test() {};

--- a/tests/organizeImports.test.ts
+++ b/tests/organizeImports.test.ts
@@ -1,0 +1,312 @@
+import prettier from 'prettier';
+import * as motokoPlugin from '../src/environments/node';
+
+const prettierOptions: prettier.Options = {
+    plugins: [motokoPlugin],
+    filepath: 'Main.mo',
+};
+
+const format = async (
+    input: string,
+    options?: prettier.Options,
+): Promise<string> => {
+    return prettier.format(input, { ...prettierOptions, ...options });
+};
+
+describe('organize imports', () => {
+    const organizeImportsOptions: prettier.Options = {
+        motokoOrganizeImports: true,
+    };
+
+    test('basic', async () => {
+        const input = `import Array "mo:base/Array";
+import Buffer "mo:base/Buffer";
+import Text "mo:base/Text";
+
+actor {}`;
+        const expected = `import Array "mo:base/Array";
+import Buffer "mo:base/Buffer";
+import Text "mo:base/Text";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('group imports by prefix', async () => {
+        const input = `import Text "mo:base/Text";
+import Utils "./utils";
+import Core "canister:core";
+import Array "mo:base/Array";
+
+actor {}`;
+        const expected = `import Core "canister:core";
+
+import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+import Utils "./utils";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('combine imports from same path', async () => {
+        const input = `import Array "mo:base/Array";
+import { map } "mo:base/Array";
+import { filter } "mo:base/Array";
+
+actor {}`;
+        const expected = `import Array "mo:base/Array";
+import { filter; map } "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('sort destructured fields', async () => {
+        const input = `import { zulu; yankee; alpha; beta } "mo:base/Utils";
+
+actor {}`;
+        const expected = `import { alpha; beta; yankee; zulu } "mo:base/Utils";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('handle aliased imports', async () => {
+        const input = `import { map = mapArray; filter = filterArray } "mo:base/Array";
+
+actor {}`;
+        const expected = `import { filter = filterArray; map = mapArray } "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('preserve code after imports', async () => {
+        const input = `import Array "mo:base/Array";
+
+let x = 5;
+let y = 10;`;
+        const expected = `import Array "mo:base/Array";
+
+let x = 5;
+let y = 10;\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('no imports to organize', async () => {
+        const input = `actor {
+  public func hello() : async Text {
+    "Hello"
+  }
+}`;
+        const expected = `actor {
+  public func hello() : async Text {
+    "Hello";
+  };
+};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('disabled by default', async () => {
+        const input = `import Text "mo:base/Text";
+import Array "mo:base/Array";
+
+actor {}`;
+        const expected = `import Text "mo:base/Text";
+import Array "mo:base/Array";
+
+actor {};\n`;
+        // Without the option, order should be preserved
+        expect(await format(input)).toEqual(expected);
+    });
+
+    test('ic: prefix imports', async () => {
+        const input = `import Array "mo:base/Array";
+import IC "ic:aaaaa-aa";
+
+actor {}`;
+        const expected = `import IC "ic:aaaaa-aa";
+
+import Array "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('empty destructured imports', async () => {
+        const input = `import Array "mo:base/Array";
+import {} "mo:base/Empty";
+
+actor {}`;
+        const expected = `import Array "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('trailing comma in destructured imports', async () => {
+        const input = `import { map; filter; } "mo:base/Array";
+
+actor {}`;
+        const expected = `import { filter; map } "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('imports with inline comments', async () => {
+        const input = `import Array "mo:base/Array"; // Array utilities
+import Text "mo:base/Text"; // Text utilities
+
+actor {}`;
+        const expected = `import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('imports with block comments', async () => {
+        const input = `/* Core imports */
+import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+actor {}`;
+        const expected = `/* Core imports */
+import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('imports with excessive whitespace', async () => {
+        const input = `import   Array   "mo:base/Array";
+import    Text    "mo:base/Text";
+
+actor {}`;
+        const expected = `import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('whitespace in destructured imports', async () => {
+        const input = `import {   map  ;  filter   ;   fold   } "mo:base/Array";
+
+actor {}`;
+        const expected = `import { filter; fold; map } "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('single item destructured import', async () => {
+        const input = `import { map } "mo:base/Array";
+
+actor {}`;
+        const expected = `import { map } "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('imports with newlines between them', async () => {
+        const input = `import Array "mo:base/Array";
+
+
+import Text "mo:base/Text";
+
+
+
+import Buffer "mo:base/Buffer";
+
+actor {}`;
+        const expected = `import Array "mo:base/Array";
+import Buffer "mo:base/Buffer";
+import Text "mo:base/Text";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('combine multiple destructured imports with existing named import', async () => {
+        const input = `import Array "mo:base/Array";
+import { map } "mo:base/Array";
+import { filter } "mo:base/Array";
+import { fold } "mo:base/Array";
+
+actor {}`;
+        const expected = `import Array "mo:base/Array";
+import { filter; fold; map } "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('complex aliased imports with sorting', async () => {
+        const input = `import { zulu = z; alpha = a; beta = b; yankee = y } "mo:base/Utils";
+
+actor {}`;
+        const expected = `import { alpha = a; beta = b; yankee = y; zulu = z } "mo:base/Utils";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('mixed aliased and non-aliased destructured imports', async () => {
+        const input = `import { map = mapFn; filter; fold = foldFn; reduce } "mo:base/Array";
+
+actor {}`;
+        const expected = `import { filter; fold = foldFn; map = mapFn; reduce } "mo:base/Array";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('imports with all prefix types mixed', async () => {
+        const input = `import Utils "./utils";
+import Buffer "mo:base/Buffer";
+import Core "canister:core";
+import IC "ic:aaaaa-aa";
+import Array "mo:base/Array";
+import Helpers "./helpers";
+import Types "canister:types";
+
+actor {}`;
+        const expected = `import IC "ic:aaaaa-aa";
+
+import Core "canister:core";
+import Types "canister:types";
+
+import Array "mo:base/Array";
+import Buffer "mo:base/Buffer";
+
+import Helpers "./helpers";
+import Utils "./utils";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('preserve spacing between imports and code', async () => {
+        const input = `import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+
+// Main actor
+actor {
+  public func test() {}
+}`;
+        const expected = `import Array "mo:base/Array";
+import Text "mo:base/Text";
+
+actor {
+  public func test() {};
+};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+});

--- a/tests/organizeImports.test.ts
+++ b/tests/organizeImports.test.ts
@@ -309,4 +309,149 @@ actor {
 };\n`;
         expect(await format(input, organizeImportsOptions)).toEqual(expected);
     });
+
+    test('malformed import - missing path', async () => {
+        const input = `import Array;
+import Text "mo:base/Text";
+
+actor {}`;
+        // Should preserve the malformed import as-is
+        const expected = `import Array;
+import Text "mo:base/Text";
+
+actor {};\n`;
+        expect(await format(input, organizeImportsOptions)).toEqual(expected);
+    });
+
+    test('malformed import - missing quotes', async () => {
+        const input = `import Array mo:base/Array;
+import Text "mo:base/Text";
+
+actor {}`;
+        // Should preserve malformed imports as-is (may reformat spacing)
+        const result = await format(input, organizeImportsOptions);
+        // Both imports should be present
+        expect(result).toContain('import Array');
+        expect(result).toContain('mo');
+        expect(result).toContain('base');
+        expect(result).toContain('Array');
+        expect(result).toContain('import Text "mo:base/Text"');
+    });
+
+    test('partially written import', async () => {
+        const input = `import Array "mo:base/Array";
+import
+
+actor {}`;
+        // Should preserve partial import as-is
+        const result = await format(input, organizeImportsOptions);
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('import');
+    });
+
+    test('incomplete destructured import', async () => {
+        const input = `import Array "mo:base/Array";
+import { map "mo:base/Array";
+
+actor {}`;
+        // Should preserve incomplete destructured import (may reformat spacing)
+        const result = await format(input, organizeImportsOptions);
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('import {map');
+        expect(result).toContain('"mo:base/Array"');
+    });
+
+    test('import with missing semicolon at end', async () => {
+        const input = `import Array "mo:base/Array"
+import Text "mo:base/Text";
+
+actor {}`;
+        // Should handle imports even without semicolons (formatter may add them)
+        const result = await format(input, organizeImportsOptions);
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('import Text "mo:base/Text"');
+    });
+
+    test('destructured import with unclosed brace', async () => {
+        const input = `import Array "mo:base/Array";
+import { map; filter "mo:base/Array";
+
+actor {}`;
+        // Should preserve malformed destructured import (may reformat)
+        const result = await format(input, organizeImportsOptions);
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('map');
+        expect(result).toContain('filter');
+        expect(result).toContain('"mo:base/Array"');
+    });
+
+    test('import with invalid path format', async () => {
+        const input = `import Array "mo:base/Array";
+import Text 'mo:base/Text';
+
+actor {}`;
+        // Single quotes might not be supported (may reformat or preserve)
+        const result = await format(input, organizeImportsOptions);
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('import Text');
+        expect(result).toContain('mo:base/Text');
+    });
+
+    test('import with syntax error in destructuring', async () => {
+        const input = `import Array "mo:base/Array";
+import { map;; filter } "mo:base/Array";
+
+actor {}`;
+        // Double semicolon is a syntax error - the organize logic should detect
+        // malformed imports and preserve them, though the formatter may clean them up
+        const result = await format(input, organizeImportsOptions);
+        // Verify that both imports are present (not removed)
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('import { ');
+        expect(result).toContain('filter');
+        expect(result).toContain('map');
+    });
+
+    test('import keyword only', async () => {
+        const input = `import Array "mo:base/Array";
+import
+import Text "mo:base/Text";
+
+actor {}`;
+        // Lone import keyword - organize logic should preserve all imports
+        const result = await format(input, organizeImportsOptions);
+        // Verify that valid imports are present
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('import Text "mo:base/Text"');
+        // The lone 'import' may be formatted but shouldn't cause data loss
+    });
+
+    test('import with incomplete alias', async () => {
+        const input = `import Array "mo:base/Array";
+import { map = } "mo:base/Array";
+
+actor {}`;
+        // Missing alias identifier - the organize logic should detect this
+        const result = await format(input, organizeImportsOptions);
+        // Both imports should be present (though may be combined/reformatted)
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('{ map }');
+    });
+
+    test('mixed valid and malformed imports', async () => {
+        const input = `import Array "mo:base/Array";
+import Buffer
+import Text "mo:base/Text";
+import { map } "mo:base/Array";
+
+actor {}`;
+        // Should preserve all imports even if some are malformed
+        const result = await format(input, organizeImportsOptions);
+        // Verify that all valid imports are present
+        expect(result).toContain('import Array "mo:base/Array"');
+        expect(result).toContain('import Text "mo:base/Text"');
+        expect(result).toContain('{ map }');
+        // The malformed 'import Buffer' without a path may be formatted
+        expect(result).toContain('Buffer');
+    });
 });


### PR DESCRIPTION
Implements "organize imports" similar to what was previously implemented in the VS Code extension. Instead of using a parsed AST, this implementation uses a token tree for more robustness to syntax errors and compatibility across a wider range of compiler versions. This implementation also confirms that all imports are preserved before applying the changes.

Example `.prettierrc`:

```json
{
    "plugins": ["prettier-plugin-motoko"],
    "motokoOrganizeImports": true
}
```
