### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Create release tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - id: create-tag
         run: RELEASE_TAG=v$(node -e "console.log(require('./packages/mo-fmt/package.json').version)") && git tag $RELEASE_TAG && git push origin $RELEASE_TAG
         continue-on-error: true
@@ -27,9 +27,9 @@ jobs:
     if: needs.tag-release.outputs.tag-outcome == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16.x
           cache: 'npm'
@@ -40,7 +40,7 @@ jobs:
         run: echo ::set-output\ name=TAG_NAME::v$(node -e "console.log(require('./packages/mo-fmt/package.json').version)")
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by GitHub Actions
         with:
@@ -51,7 +51,7 @@ jobs:
           prerelease: false
       - name: Upload release (Linux)
         id: upload-release-linux
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -61,7 +61,7 @@ jobs:
           asset_content_type: application/octet-stream
       - name: Upload release (macOS)
         id: upload-release-macos
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -71,7 +71,7 @@ jobs:
           asset_content_type: application/octet-stream
       - name: Upload release (Windows)
         id: upload-release-windows
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,13 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - run: git clone https://github.com/dfinity/motoko.git ../motoko --depth 1
     - run: npm ci
     - run: npm i prettier


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0`
  - Version: v3.6.0 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744

- `actions/setup-node@v3` -> `actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1`
  - Version: v3.9.1 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/3235b876344d2a9aa001b8d1453c930bba69e610

- `actions/create-release@v1` -> `actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4`
  - Version: v1.1.4 | Latest: v1.1.4 | Release age: 2034d
  - Commit: https://github.com/actions/create-release/commit/0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e

- `actions/upload-release-asset@v1` -> `actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2`
  - Version: v1.0.2 | Latest: v1.0.2 | Release age: 2251d
  - Commit: https://github.com/actions/upload-release-asset/commit/e8f9f06c4b078e705bd2ea027f0926603fc9b4d5

- `Swatinem/rust-cache@v2` -> `Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2`
  - Version: v2 | Latest: v2.9.1 | Release age: 28d
  - Commit: https://github.com/Swatinem/rust-cache/commit/e18b497796c12c097a38f9edb9d0641fb99eee32


### Files modified

- `.github/workflows/release.yml`
- `.github/workflows/tests.yml`